### PR TITLE
Improvements to samples and README.md

### DIFF
--- a/Microsoft.WindowsAzure.Storage/samples/BlobsGettingStarted/Application.cpp
+++ b/Microsoft.WindowsAzure.Storage/samples/BlobsGettingStarted/Application.cpp
@@ -30,12 +30,36 @@ namespace azure { namespace storage { namespace samples {
         return utility::string_t(data.cbegin(), data.cend());
     }
 
+    utility::string_t get_connection_string()
+    {
+        // Load configuration
+        utility::ifstream_t config_file;
+        config_file.open("test_configurations.json");
+
+        web::json::value config;
+        config_file >> config;
+
+        auto target_name = config[U("target")].as_string();
+        web::json::value& tenants = config[U("tenants")];
+
+        for (web::json::array::const_iterator it = tenants.as_array().cbegin(); it != tenants.as_array().cend(); ++it)
+        {
+            const web::json::value& name_obj = it->at(U("name"));
+            if (name_obj.as_string() == target_name)
+            {
+                return it->at(U("connection_string")).as_string();
+            }
+        }
+    }
+
     void blobs_getting_started_sample()
     {
         try
         {
-            // Initialize storage account
-            azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(storage_connection_string);
+	    
+	    
+            // Initialize storage account, get connection string from test_configurations.json
+            azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(get_connection_string());
 
             // Create a blob container
             azure::storage::cloud_blob_client blob_client = storage_account.create_cloud_blob_client();

--- a/Microsoft.WindowsAzure.Storage/samples/Channel9GoingNativeDemo1/NativeClientLibraryDemo1.cpp
+++ b/Microsoft.WindowsAzure.Storage/samples/Channel9GoingNativeDemo1/NativeClientLibraryDemo1.cpp
@@ -6,11 +6,33 @@
 #include "was/table.h"
 #include "was/queue.h"
 
+utility::string_t get_connection_string()
+{
+    // Load configuration
+    utility::ifstream_t config_file;
+    config_file.open("test_configurations.json");
+
+    web::json::value config;
+    config_file >> config;
+
+    auto target_name = config[U("target")].as_string();
+    web::json::value& tenants = config[U("tenants")];
+
+    for (web::json::array::const_iterator it = tenants.as_array().cbegin(); it != tenants.as_array().cend(); ++it)
+    {
+        const web::json::value& name_obj = it->at(U("name"));
+        if (name_obj.as_string() == target_name)
+        {
+            return it->at(U("connection_string")).as_string();
+        }
+    }
+}
+
 int _tmain(int argc, _TCHAR* argv[])
 {
     try
     {
-        azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(U("DefaultEndpointsProtocol=https;AccountName=ACCOUNT_NAME;AccountKey=ACCOUNT_KEY"));
+        azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(U(get_connection_string()));
 
         azure::storage::cloud_table_client table_client = storage_account.create_cloud_table_client();
         azure::storage::cloud_table table = table_client.get_table_reference(U("blogposts"));

--- a/Microsoft.WindowsAzure.Storage/samples/Channel9GoingNativeDemo2/NativeClientLibraryDemo2.cpp
+++ b/Microsoft.WindowsAzure.Storage/samples/Channel9GoingNativeDemo2/NativeClientLibraryDemo2.cpp
@@ -6,11 +6,33 @@
 #include "was/table.h"
 #include "was/queue.h"
 
+utility::string_t get_connection_string()
+{
+    // Load configuration
+    utility::ifstream_t config_file;
+    config_file.open("test_configurations.json");
+
+    web::json::value config;
+    config_file >> config;
+
+    auto target_name = config[U("target")].as_string();
+    web::json::value& tenants = config[U("tenants")];
+
+    for (web::json::array::const_iterator it = tenants.as_array().cbegin(); it != tenants.as_array().cend(); ++it)
+    {
+        const web::json::value& name_obj = it->at(U("name"));
+        if (name_obj.as_string() == target_name)
+        {
+            return it->at(U("connection_string")).as_string();
+        }
+    }
+}
+
 int _tmain(int argc, _TCHAR* argv[])
 {
     try
     {
-        azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(U("DefaultEndpointsProtocol=https;AccountName=ACCOUNT_NAME;AccountKey=ACCOUNT_KEY"));
+        azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(U(get_connection_string()));
 
         azure::storage::cloud_table_client table_client = storage_account.create_cloud_table_client();
         azure::storage::cloud_table table = table_client.get_table_reference(U("blogposts"));

--- a/Microsoft.WindowsAzure.Storage/samples/JsonPayloadFormat/Application.cpp
+++ b/Microsoft.WindowsAzure.Storage/samples/JsonPayloadFormat/Application.cpp
@@ -23,12 +23,34 @@
 
 namespace azure { namespace storage { namespace samples {
 
+    utility::string_t get_connection_string()
+    {
+        // Load configuration
+        utility::ifstream_t config_file;
+        config_file.open("test_configurations.json");
+
+        web::json::value config;
+        config_file >> config;
+
+        auto target_name = config[U("target")].as_string();
+        web::json::value& tenants = config[U("tenants")];
+
+        for (web::json::array::const_iterator it = tenants.as_array().cbegin(); it != tenants.as_array().cend(); ++it)
+        {
+            const web::json::value& name_obj = it->at(U("name"));
+            if (name_obj.as_string() == target_name)
+            {
+                return it->at(U("connection_string")).as_string();
+            }
+        }
+    }
+
     void tables_getting_started_sample()
     {
         try
         {
             // Initialize storage account
-            azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(storage_connection_string);
+  	    azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(get_connection_string());
 
             // Create a table
             azure::storage::cloud_table_client table_client = storage_account.create_cloud_table_client();

--- a/Microsoft.WindowsAzure.Storage/samples/QueuesGettingStarted/Application.cpp
+++ b/Microsoft.WindowsAzure.Storage/samples/QueuesGettingStarted/Application.cpp
@@ -23,12 +23,34 @@
 
 namespace azure { namespace storage { namespace samples {
 
+    utility::string_t get_connection_string()
+    {
+        // Load configuration
+        utility::ifstream_t config_file;
+        config_file.open("test_configurations.json");
+
+        web::json::value config;
+        config_file >> config;
+
+        auto target_name = config[U("target")].as_string();
+        web::json::value& tenants = config[U("tenants")];
+
+        for (web::json::array::const_iterator it = tenants.as_array().cbegin(); it != tenants.as_array().cend(); ++it)
+        {
+            const web::json::value& name_obj = it->at(U("name"));
+            if (name_obj.as_string() == target_name)
+            {
+                return it->at(U("connection_string")).as_string();
+            }
+        }
+    }
+
     void queues_getting_started_sample()
     {
         try
         {
             // Initialize storage account
-            azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(storage_connection_string);
+	    azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(get_connection_string());
 
             // Create a queue
             azure::storage::cloud_queue_client queue_client = storage_account.create_cloud_queue_client();

--- a/Microsoft.WindowsAzure.Storage/samples/TablesGettingStarted/Application.cpp
+++ b/Microsoft.WindowsAzure.Storage/samples/TablesGettingStarted/Application.cpp
@@ -23,12 +23,34 @@
 
 namespace azure { namespace storage { namespace samples {
 
+    utility::string_t get_connection_string()
+    {
+        // Load configuration
+        utility::ifstream_t config_file;
+        config_file.open("test_configurations.json");
+
+        web::json::value config;
+        config_file >> config;
+
+        auto target_name = config[U("target")].as_string();
+        web::json::value& tenants = config[U("tenants")];
+
+        for (web::json::array::const_iterator it = tenants.as_array().cbegin(); it != tenants.as_array().cend(); ++it)
+        {
+            const web::json::value& name_obj = it->at(U("name"));
+            if (name_obj.as_string() == target_name)
+            {
+                return it->at(U("connection_string")).as_string();
+            }
+        }
+    }
+
     void tables_getting_started_sample()
     {
         try
         {
             // Initialize storage account
-            azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(storage_connection_string);
+	    azure::storage::cloud_storage_account storage_account = azure::storage::cloud_storage_account::parse(get_connection_string());
 
             // Create a table
             azure::storage::cloud_table_client table_client = storage_account.create_cloud_table_client();

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ sudo apt-get install libunittest++-dev
 ```
 - Build the test code:
 ```bash
-CASABLANCA_DIR=<path to Casablanca> CXX=g++-4.8 cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS
+CASABLANCA_DIR=<path to Casablanca> CXX=g++-4.8 cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=1
 make
 ```
 - Run unit tests
@@ -119,7 +119,7 @@ vi test_configurations.json # modify test config file to include your storage ac
 
 To build sample code:
 ```bash
-CASABLANCA_DIR=<path to Casablanca> CXX=g++-4.8 cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SAMPLES
+CASABLANCA_DIR=<path to Casablanca> CXX=g++-4.8 cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SAMPLES=1
 make
 ```
 To run the samples:


### PR DESCRIPTION
I've made changes to the samples so they read the connection string from the same test_configurations.json file used for testing, rather than being buried deep in the source code. This means the samples can be run out of the box. 

README.md was amended to have cmake not choke and was discussed in an issue I submitted. 
