### PR TITLE
Allow static linking of boost_log

### DIFF
--- a/Microsoft.WindowsAzure.Storage/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/CMakeLists.txt
@@ -44,7 +44,9 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
  
   set(STRICT_CXX_FLAGS ${WARNINGS} "-Werror -pedantic")
  
-  add_definitions(-DBOOST_LOG_DYN_LINK)
+  if(NOT Boost_USE_STATIC_LIBS)
+    add_definitions(-DBOOST_LOG_DYN_LINK)
+  endif()
 else()
   message("-- Unknown compiler, success is doubtful.")
 endif()


### PR DESCRIPTION
Modify CMakeLists.txt to allow static linking to boost_log in the event that Boost_USE_STATIC_LIBS is defined to true (if it is, linking will fail with BOOST_LOG_DYN_LINK defined as the ABI is wrong for the static library)
