### PR TITLE
Use Boost Log dynamic lib only for shared lib build

### DIFF
--- a/Microsoft.WindowsAzure.Storage/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/CMakeLists.txt
@@ -44,7 +44,9 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
  
   set(STRICT_CXX_FLAGS ${WARNINGS} "-Werror -pedantic")
  
-  add_definitions(-DBOOST_LOG_DYN_LINK)
+  if (BUILD_SHARED_LIBS)
+    add_definitions(-DBOOST_LOG_DYN_LINK)
+  endif()
 else()
   message("-- Unknown compiler, success is doubtful.")
 endif()


### PR DESCRIPTION
So that static lib build can be used with static Boost Log lib.