### PR TITLE
Fix xml parser for table's error message

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/wascore/constants.h
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/constants.h
@@ -280,6 +280,7 @@ namespace azure { namespace storage { namespace protocol {
     const utility::string_t xml_name(_XPLATSTR("Name"));
     const utility::string_t xml_size(_XPLATSTR("Size"));
     const utility::string_t xml_error_root(_XPLATSTR("Error"));
+    const utility::string_t xml_error_root_table(_XPLATSTR("error"));
     const utility::string_t xml_code(_XPLATSTR("Code"));
     const utility::string_t xml_code_table(_XPLATSTR("code"));
     const utility::string_t xml_message(_XPLATSTR("Message"));

--- a/Microsoft.WindowsAzure.Storage/src/protocol_xml.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/protocol_xml.cpp
@@ -31,6 +31,14 @@ namespace azure { namespace storage { namespace protocol {
         {
             m_error_message = get_current_element_text();
         }
+        else if (element_name == xml_code_table && get_parent_element_name() == xml_error_root_table)
+        {
+            m_error_code = get_current_element_text();
+        }
+        else if (element_name == xml_message_table && get_parent_element_name() == xml_error_root_table)
+        {
+            m_error_message = get_current_element_text();
+        }
         else
         {
             m_details.insert(std::make_pair(element_name, get_current_element_text()));

--- a/Microsoft.WindowsAzure.Storage/tests/storage_exception_test.cpp
+++ b/Microsoft.WindowsAzure.Storage/tests/storage_exception_test.cpp
@@ -65,4 +65,28 @@ SUITE(Core)
             CHECK(!e.result().extended_error().message().empty());
         }
     }
+
+    TEST_FIXTURE(table_service_test_base, storage_extended_error_verify_xml_with_details)
+    {
+        utility::string_t table_name = get_table_name();
+        azure::storage::cloud_table_client client = get_table_client();
+        azure::storage::cloud_table table = client.get_table_reference(table_name);
+
+        azure::storage::table_request_options options;
+        azure::storage::operation_context context;
+        context.set_sending_request([](web::http::http_request &r, azure::storage::operation_context) {
+            r.headers()[_XPLATSTR("Accept")] = _XPLATSTR("application/xml");
+        });
+
+        try
+        {
+            table.exists(options, context);
+            CHECK(false);
+        }
+        catch (const azure::storage::storage_exception& e)
+        {
+            CHECK(e.result().extended_error().code().compare(_XPLATSTR("MediaTypeNotSupported")) == 0);
+            CHECK(!e.result().extended_error().message().empty());
+        }
+    }
 }


### PR DESCRIPTION
Table service's error code and error message use lower case XML in order to compatible with OData spec. But other services use error code and error message with uppercase for the first letter. This cause the xml parser didn't correctly parse the error code and error message.
