### PR TITLE
Order initializers to match class members

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/was/blob.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/blob.h
@@ -1220,9 +1220,10 @@ namespace azure { namespace storage {
         /// Initializes a new instance of the <see cref="azure::storage::cloud_blob_properties" /> class.
         /// </summary>
         cloud_blob_properties()
-            : m_type(blob_type::unspecified), m_page_blob_sequence_number(0), m_append_blob_committed_block_count(0),
-            m_lease_state(azure::storage::lease_state::unspecified), m_lease_status(azure::storage::lease_status::unspecified),
-            m_lease_duration(azure::storage::lease_duration::unspecified), m_size(0)
+            :  m_size(0), m_type(blob_type::unspecified), m_lease_status(azure::storage::lease_status::unspecified),
+            m_lease_state(azure::storage::lease_state::unspecified),
+            m_lease_duration(azure::storage::lease_duration::unspecified),
+            m_page_blob_sequence_number(0), m_append_blob_committed_block_count(0)
         {
         }
 
@@ -1653,10 +1654,10 @@ namespace azure { namespace storage {
             m_use_transactional_md5(false),
             m_store_blob_content_md5(false),
             m_disable_content_md5_validation(false),
-            m_single_blob_upload_threshold(protocol::default_single_blob_upload_threshold),
-            m_stream_read_size(protocol::max_block_size),
-            m_stream_write_size(protocol::max_block_size),
             m_parallelism_factor(1),
+            m_single_blob_upload_threshold(protocol::default_single_blob_upload_threshold),
+            m_stream_write_size(protocol::max_block_size),
+            m_stream_read_size(protocol::max_block_size),
             m_absorb_conditional_errors_on_retry(false)
         {
         }
@@ -3887,7 +3888,7 @@ namespace azure { namespace storage {
         /// Initializes a new instance of the <see cref="azure::storage::cloud_blob" /> class.
         /// </summary>
         cloud_blob()
-            : m_metadata(std::make_shared<cloud_metadata>()), m_properties(std::make_shared<cloud_blob_properties>()), m_copy_state(std::make_shared<azure::storage::copy_state>())
+            : m_properties(std::make_shared<cloud_blob_properties>()), m_metadata(std::make_shared<cloud_metadata>()), m_copy_state(std::make_shared<azure::storage::copy_state>())
         {
             set_type(blob_type::unspecified);
         }
@@ -6982,8 +6983,9 @@ namespace azure { namespace storage {
         /// <param name="metadata">User-defined metadata for the blob.</param>
         /// <param name="copy_state">the state of the most recent or pending copy operation.</param>
         explicit list_blob_item(utility::string_t blob_name, utility::string_t snapshot_time, cloud_blob_container container, cloud_blob_properties properties, cloud_metadata metadata, copy_state copy_state)
-            : m_is_blob(true), m_name(std::move(blob_name)), m_snapshot_time(std::move(snapshot_time)), m_container(std::move(container)),
-            m_properties(std::move(properties)), m_metadata(std::move(metadata)), m_copy_state(std::move(copy_state))
+            : m_is_blob(true), m_name(std::move(blob_name)), m_container(std::move(container)),
+            m_snapshot_time(std::move(snapshot_time)), m_properties(std::move(properties)),
+            m_metadata(std::move(metadata)), m_copy_state(std::move(copy_state))
         {
         }
 

--- a/Microsoft.WindowsAzure.Storage/includes/was/common.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/common.h
@@ -597,7 +597,7 @@ namespace azure { namespace storage {
             /// Initializes a new instance of the <see cref="azure::storage::service_properties::logging_properties" /> struct.
             /// </summary>
             logging_properties()
-                : m_delete_enabled(false), m_read_enabled(false), m_write_enabled(false), m_retention_enabled(false), m_retention_days(0)
+                : m_read_enabled(false), m_write_enabled(false), m_delete_enabled(false), m_retention_enabled(false), m_retention_days(0)
             {
             }
 
@@ -2311,7 +2311,7 @@ namespace azure { namespace storage {
         /// Initializes a new instance of the <see cref="azure::storage::shared_access_policy" /> class.
         /// </summary>
         shared_access_policy()
-            : m_permission(none), m_protocol(protocols::https_or_http)
+            : m_protocol(protocols::https_or_http), m_permission(none)
         {
         }
 
@@ -2321,7 +2321,7 @@ namespace azure { namespace storage {
         /// <param name="expiry">The expiration date and time for the shared access policy.</param>
         /// <param name="permission">A mask specifying permissions for the shared access policy.</param>
         shared_access_policy(utility::datetime expiry, uint8_t permission)
-            : m_permission(permission), m_expiry(expiry), m_protocol(protocols::https_or_http)
+            : m_expiry(expiry), m_protocol(protocols::https_or_http), m_permission(permission)
         {
         }
 
@@ -2332,7 +2332,7 @@ namespace azure { namespace storage {
         /// <param name="expiry">The expiration date and time for the shared access policy.</param>
         /// <param name="permission">A mask specifying permissions for the shared access policy.</param>
         shared_access_policy(utility::datetime start, utility::datetime expiry, uint8_t permission)
-            : m_permission(permission), m_start(start), m_expiry(expiry), m_protocol(protocols::https_or_http)
+            : m_start(start), m_expiry(expiry), m_protocol(protocols::https_or_http), m_permission(permission)
         {
         }
 
@@ -2345,7 +2345,7 @@ namespace azure { namespace storage {
         /// <param name="protocol">The allowed protocols for a shared access signature associated with this shared access policy.</param>
         /// <param name="address">The allowed IP address for a shared access signature associated with this shared access policy.</param>
         shared_access_policy(utility::datetime start, utility::datetime expiry, uint8_t permission, protocols protocol, utility::string_t address)
-            : m_permission(permission), m_start(start), m_expiry(expiry), m_protocol(protocol), m_ip_address_or_range(ip_address_or_range(std::move(address)))
+            : m_start(start), m_expiry(expiry), m_protocol(protocol), m_ip_address_or_range(ip_address_or_range(std::move(address))), m_permission(permission)
         {
         }
 
@@ -2359,7 +2359,7 @@ namespace azure { namespace storage {
         /// <param name="minimum_address">The minimum allowed address for an IP range for the shared access policy.</param>
         /// <param name="maximum_address">The maximum allowed address for an IP range for the shared access policy.</param>
         shared_access_policy(utility::datetime start, utility::datetime expiry, uint8_t permission, protocols protocol, utility::string_t minimum_address, utility::string_t maximum_address)
-            : m_permission(permission), m_start(start), m_expiry(expiry), m_protocol(protocol), m_ip_address_or_range(ip_address_or_range(std::move(minimum_address), std::move(maximum_address)))
+            : m_start(start), m_expiry(expiry), m_protocol(protocol), m_ip_address_or_range(ip_address_or_range(std::move(minimum_address), std::move(maximum_address))), m_permission(permission)
         {
         }
 

--- a/Microsoft.WindowsAzure.Storage/includes/was/retry_policies.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/retry_policies.h
@@ -178,8 +178,9 @@ namespace azure { namespace storage {
         /// <param name="delta_backoff">The delta backoff.</param>
         /// <param name="max_attempts">The maximum number of retries to attempt.</param>
         basic_exponential_retry_policy(std::chrono::seconds delta_backoff, int max_attempts)
-            : basic_common_retry_policy(max_attempts), m_delta_backoff(delta_backoff),
-            m_rand_distribution(static_cast<double>(delta_backoff.count()) * 0.8, static_cast<double>(delta_backoff.count()) * 1.2)
+            : basic_common_retry_policy(max_attempts),
+            m_rand_distribution(static_cast<double>(delta_backoff.count()) * 0.8, static_cast<double>(delta_backoff.count()) * 1.2),
+            m_delta_backoff(delta_backoff)
         {
         }
 

--- a/Microsoft.WindowsAzure.Storage/includes/was/storage_account.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/storage_account.h
@@ -41,7 +41,7 @@ namespace azure { namespace storage {
         /// Initializes a new instance of the <see cref="azure::storage::cloud_storage_account" /> class.
         /// </summary>
         cloud_storage_account()
-            : m_initialized(false), m_is_development_storage_account(false), m_default_endpoints(false)
+            : m_initialized(false), m_default_endpoints(false), m_is_development_storage_account(false)
         {
         }
 
@@ -54,7 +54,7 @@ namespace azure { namespace storage {
         /// <param name="queue_endpoint">The Queue service endpoint.</param>
         /// <param name="table_endpoint">The Table service endpoint.</param>
         cloud_storage_account(const storage_credentials& credentials, const storage_uri& blob_endpoint, const storage_uri& queue_endpoint, const storage_uri& table_endpoint)
-            : m_initialized(true), m_is_development_storage_account(false), m_credentials(credentials), m_blob_endpoint(blob_endpoint), m_queue_endpoint(queue_endpoint), m_table_endpoint(table_endpoint), m_default_endpoints(false)
+            : m_initialized(true), m_default_endpoints(false), m_is_development_storage_account(false), m_blob_endpoint(blob_endpoint), m_queue_endpoint(queue_endpoint), m_table_endpoint(table_endpoint), m_credentials(credentials)
         {
         }
 
@@ -65,7 +65,7 @@ namespace azure { namespace storage {
         /// <param name="credentials">The <see cref="azure::storage::storage_credentials" /> to use.</param>
         /// <param name="use_https"><c>true</c> to use HTTPS to connect to storage service endpoints; otherwise, <c>false</c>.</param>
         cloud_storage_account(const storage_credentials& credentials, bool use_https)
-            : m_initialized(true), m_is_development_storage_account(false), m_credentials(credentials), m_default_endpoints(true)
+            : m_initialized(true), m_default_endpoints(true), m_is_development_storage_account(false), m_credentials(credentials)
         {
             initialize_default_endpoints(use_https);
         }
@@ -78,7 +78,7 @@ namespace azure { namespace storage {
         /// <param name="endpoint_suffix">The DNS endpoint suffix for the storage services, e.g., &quot;core.windows.net&quot;.</param>
         /// <param name="use_https"><c>true</c> to use HTTPS to connect to storage service endpoints; otherwise, <c>false</c>.</param>
         cloud_storage_account(const storage_credentials& credentials, const utility::string_t& endpoint_suffix, bool use_https)
-            : m_initialized(true), m_is_development_storage_account(false), m_credentials(credentials), m_default_endpoints(true), m_endpoint_suffix(endpoint_suffix)
+            : m_initialized(true), m_default_endpoints(true), m_is_development_storage_account(false), m_credentials(credentials), m_endpoint_suffix(endpoint_suffix)
         {
             initialize_default_endpoints(use_https);
         }

--- a/Microsoft.WindowsAzure.Storage/includes/was/table.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/table.h
@@ -752,7 +752,7 @@ namespace azure { namespace storage {
         /// <param name="etag">The entity's current ETag.</param>
         /// <param name="properties">The entity's properties, indexed by property name.</param>
         table_entity(utility::string_t partition_key, utility::string_t row_key, utility::string_t etag, properties_type properties)
-            : m_partition_key(std::move(partition_key)), m_row_key(std::move(row_key)), m_etag(std::move(etag)), m_properties(std::move(properties))
+            : m_properties(std::move(properties)), m_partition_key(std::move(partition_key)), m_row_key(std::move(row_key)), m_etag(std::move(etag))
         {
         }
 


### PR DESCRIPTION
My use of the SDK generates warnings about initializers on various constructors appearing in the wrong order (i.e. not matching the order of the initialized members as they are declared). Rather than continue to suppress the warnings (e.g. -Wno-reorder for g++/clang++), it seemed wiser to just fix the headers so the initializers appeared in the correct order.