### PR TITLE
Build on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,9 @@ $RECYCLE.BIN/
 
 # build folders under Linux
 Microsoft.WindowsAzure.Storage/build.*/
+
+# ==========================
+# OSX detritus
+# ==========================
+
+*.DS_Store

--- a/Microsoft.WindowsAzure.Storage/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/CMakeLists.txt
@@ -15,7 +15,25 @@ option(BUILD_SAMPLES "Build sample codes" OFF)
 if(UNIX)
   find_package(Boost REQUIRED COMPONENTS log log_setup random system thread locale regex filesystem chrono date_time)
   find_package(Threads REQUIRED)
-  find_package(OpenSSL REQUIRED)
+  if(APPLE)
+	 message(WARNING "On OSX you must specify OPENSSL_ROOT_DIR, it is currently ${OPENSSL_ROOT_DIR}")
+
+	  # this isn't ideal because it requires the user to set OPENSSL_ROOT_DIR rather than being automated
+	  set(OPENSSL_FOUND 1)
+	  set(OPENSSL_INCLUDE_DIR "${OPENSSL_ROOT_DIR}/include")
+	  set(OPENSSL_LIBRARIES
+		"${OPENSSL_ROOT_DIR}/lib/libcrypto.dylib"
+		"${OPENSSL_ROOT_DIR}/lib/libssl.dylib"
+		)
+
+		message(WARNING "On OSX you must specify GETTEXT_LIB_DIR, it is currently ${GETTEXT_LIB_DIR}")
+		set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${GETTEXT_LIB_DIR}")
+
+		
+
+  else()
+  	find_package(OpenSSL REQUIRED)
+  endif()
   find_package(Glibmm REQUIRED)
   find_package(LibXML++ REQUIRED)
   find_package(UUID REQUIRED)
@@ -46,15 +64,31 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   set(WARNINGS "${WARNINGS} ${LINUX_SUPPRESSIONS}")
 
   set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs")
- 
+
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
- 
+
   set(STRICT_CXX_FLAGS ${WARNINGS} "-Werror -pedantic")
- 
-  if (BUILD_SHARED_LIBS)    
-    add_definitions(-DBOOST_LOG_DYN_LINK)    
-  endif()    
-  add_definitions(-D_TURN_OFF_PLATFORM_STRING)  
+
+  if (BUILD_SHARED_LIBS)
+    add_definitions(-DBOOST_LOG_DYN_LINK)
+  endif()
+  add_definitions(-D_TURN_OFF_PLATFORM_STRING)
+elseif((CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+	message("-- Setting clang options")
+
+	set(WARNINGS "-Wall -Wextra -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls")
+	set(OSX_SUPPRESSIONS "-Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wno-shorten-64-to-32 -Wno-reorder -Wno-unused-local-typedefs")
+	set(WARNINGS "${WARNINGS} ${OSX_SUPPRESSIONS}")
+
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-return-type-c-linkage -Wno-unneeded-internal-declaration")
+	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
+	if (BUILD_SHARED_LIBS)
+		add_definitions(-DBOOST_LOG_DYN_LINK)
+	endif()
+	add_definitions(-D_TURN_OFF_PLATFORM_STRING)
 else()
   message("-- Unknown compiler, success is doubtful.")
 endif()
@@ -80,7 +114,7 @@ add_subdirectory(src)
 
 if(BUILD_TESTS)
   set(AZURESTORAGE_LIBRARY_TEST azurestoragetest)
-  add_subdirectory(tests) 
+  add_subdirectory(tests)
 endif()
 
 if(BUILD_SAMPLES)

--- a/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories(${Boost_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
 include_directories(${AZURESTORAGE_INCLUDE_DIRS})
 
 # THE ORDER OF FILES IS VERY /VERY/ IMPORTANT
@@ -54,6 +55,7 @@ endif()
 if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
 
 add_library(${AZURESTORAGE_LIBRARY} ${SOURCES})
 
@@ -71,4 +73,3 @@ if(UNIX)
     ARCHIVE DESTINATION lib
     )
 endif()
-

--- a/Microsoft.WindowsAzure.Storage/src/resources.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/resources.cpp
@@ -20,10 +20,10 @@
 
 namespace azure { namespace storage { namespace protocol {
 
-#define _RECOURSES
+#define _RESOURCES
 #define DAT(a, b) const char* a = b;
 #include "wascore/constants.dat"
 #undef DAT
-#undef _RECOURSES
+#undef _RESOURCES
 
 }}} // namespace azure::storage::protocol

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Azure Storage Client Library for C++ allows you to build applications agains
 
 # Getting started
 
-For the best development experience, we recommend that developers use the official Microsoft NuGet packages for libraries. NuGet packages are regularly updated with new functionality and hotfixes. 
+For the best development experience, we recommend that developers use the official Microsoft NuGet packages for libraries. NuGet packages are regularly updated with new functionality and hotfixes.
 Download the [NuGet Package](http://www.nuget.org/packages/wastorage).
 
 ## Requirements
@@ -33,7 +33,7 @@ We gladly accept community contributions.
 
 - **Issues:** Report bugs on the [Issues page](https://github.com/Azure/azure-storage-cpp/issues) in GitHub.
 - **Forums:** Communicate with the Azure Storage development team on the [Azure Storage Forum](https://social.msdn.microsoft.com/Forums/azure/en-US/home?forum=windowsazuredata) or [StackOverflow](http://stackoverflow.com/questions/tagged/azure).
-- **Source Code Contributions:** Please follow the [contribution guidelines for Azure open source](http://azure.github.io/guidelines/) for instructions about contributing to the source project. 
+- **Source Code Contributions:** Please follow the [contribution guidelines for Azure open source](http://azure.github.io/guidelines/) for instructions about contributing to the source project.
 
 For general suggestions about Azure, use our [Azure feedback forum](http://feedback.azure.com/forums/34192--general-feedback).
 
@@ -133,6 +133,44 @@ cd Binaries
 
 Please note the current build script is only tested on Ubuntu 14.04. Please update the script accordingly for other distributions.
 
+## Getting Started on OSX
+
+*Note that OSX is not officially supported yet, but it has been seen to work, YMMV. This build has been tested to work when the dependencies are installed via homebrew, YMMV if using FINK or MacPorts*
+
+Install dependecies with homebrew:
+
+```
+brew install glibmm libxml++ libsigc++ ossp-uuid gettext openssl
+```
+
+As mentioned above, the Azure Storage Client Library for C++ depends on Casablanca. Follow [these instructions](https://github.com/Microsoft/cpprestsdk/wiki/How-to-build-for-Mac-OS-X) to compile it. Current version of the library depends on Casablanca version 2.8.0.
+
+Once this is complete, then:
+
+- Clone the project using git:
+```bash
+git clone https://github.com/Azure/azure-storage-cpp.git
+```
+The project is cloned to a folder called `azure-storage-cpp`. Always use the master branch, which contains the latest release.
+- Install additional dependencies:
+```bash
+sudo apt-get install libxml++2.6-dev libxml++2.6-doc uuid-dev
+```
+- Build the SDK for Release:
+```bash
+cd azure-storage-cpp/Microsoft.WIndowsAzure.Storage
+mkdir build.release
+cd build.release
+CASABLANCA_DIR=<path to Casablanca> cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=<path to openssl> -DGETTEXT_LIB_DIR=<path to gettext lib dir>
+make
+```
+In the above command, replace `<path to Casablanca>` to point to your local installation of Casablanca. <path to openssl> to your local openssl, it is recommended not to use the version that comes with OSX, rather use one from Homebrew or the like. <path to gettext lib dir> is similar, although you go all the way to the lib dir. For example, if the file `libcpprest.so` exists at location `~/Github/Casablanca/cpprestsdk/Release/build.release/Binaries/libcpprest.so`, and you've installed the dependencies through homebrew then your `cmake` command should be:
+```bash
+CASABLANCA_DIR=~/Github/Casablanca/cpprestsdk cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DGETTEXT_LIB_DIR=/usr/local/opt/gettext/lib
+```
+The library is generated under `azure-storage-cpp/Microsoft.WindowsAzure.Storage/build.release/Binaries/`.
+
+*As yet the unit tests don't build, because cmake won't find UnitTest++ even though it is installed via Homebrew*
 
 # Learn More
 - [Microsoft Azure Storage Client Library for C++ v2.0.0](documentation/Microsoft%20Azure%20Storage%20Client%20Library%20for%20C%2B%2B%202.0.0.md)


### PR DESCRIPTION
This aims to fix #27 and #71

Borrowed a lot from the cpprestsdk CMAKE, the changes revolved around:
* using the correct OpenSSL, because homebrew installs it "Keg Only"
* injecting a missing -L directive for gettext (libintl)
* adding -DBOOST_LOG_DYN_LINK to make boost link properly
* adding the same warnings/suppressions/cflags as Casablanca

In resources.cpp changed _RECOURSES to _RESOURCES