### PR TITLE
Fixed a spelling error in resources.cpp

### DIFF
--- a/Microsoft.WindowsAzure.Storage/src/resources.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/resources.cpp
@@ -20,10 +20,10 @@
 
 namespace azure { namespace storage { namespace protocol {
 
-#define _RECOURSES
+#define _RESOURCES
 #define DAT(a, b) const char* a = b;
 #include "wascore/constants.dat"
 #undef DAT
-#undef _RECOURSES
+#undef _RESOURCES
 
 }}} // namespace azure::storage::protocol


### PR DESCRIPTION
This was cherry-picked out of a previous PR so that it is separate.

Relates to issue #74 

Presumably this was preventing all builds from working, as
the resources from the dat file were not being included because
the #ifdef was failing.