### PR TITLE
Fix osx cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,9 @@ $RECYCLE.BIN/
 
 # build folders under Linux
 Microsoft.WindowsAzure.Storage/build.*/
+
+# ==========================
+# OSX detritus
+# ==========================
+
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -187,4 +187,4 @@ Microsoft.WindowsAzure.Storage/build.*/
 # OSX detritus
 # ==========================
 
-*.DS_Store
+.DS_Store

--- a/Microsoft.WindowsAzure.Storage/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/CMakeLists.txt
@@ -15,7 +15,25 @@ option(BUILD_SAMPLES "Build sample codes" OFF)
 if(UNIX)
   find_package(Boost REQUIRED COMPONENTS log log_setup random system thread locale regex filesystem chrono date_time)
   find_package(Threads REQUIRED)
-  find_package(OpenSSL REQUIRED)
+  if(APPLE)
+	 message(WARNING "On OSX you must specify OPENSSL_ROOT_DIR, it is currently ${OPENSSL_ROOT_DIR}")
+
+	  # this isn't ideal because it requires the user to set OPENSSL_ROOT_DIR rather than being automated
+	  set(OPENSSL_FOUND 1)
+	  set(OPENSSL_INCLUDE_DIR "${OPENSSL_ROOT_DIR}/include")
+	  set(OPENSSL_LIBRARIES
+		"${OPENSSL_ROOT_DIR}/lib/libcrypto.dylib"
+		"${OPENSSL_ROOT_DIR}/lib/libssl.dylib"
+		)
+
+		message(WARNING "On OSX you must specify GETTEXT_LIB_DIR, it is currently ${GETTEXT_LIB_DIR}")
+		set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${GETTEXT_LIB_DIR}")
+
+		
+
+  else()
+  	find_package(OpenSSL REQUIRED)
+  endif()
   find_package(Glibmm REQUIRED)
   find_package(LibXML++ REQUIRED)
   find_package(UUID REQUIRED)
@@ -46,15 +64,31 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   set(WARNINGS "${WARNINGS} ${LINUX_SUPPRESSIONS}")
 
   set(LD_FLAGS "${LD_FLAGS} -Wl,-z,defs")
- 
+
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
- 
+
   set(STRICT_CXX_FLAGS ${WARNINGS} "-Werror -pedantic")
- 
-  if (BUILD_SHARED_LIBS)    
-    add_definitions(-DBOOST_LOG_DYN_LINK)    
-  endif()    
-  add_definitions(-D_TURN_OFF_PLATFORM_STRING)  
+
+  if (BUILD_SHARED_LIBS)
+    add_definitions(-DBOOST_LOG_DYN_LINK)
+  endif()
+  add_definitions(-D_TURN_OFF_PLATFORM_STRING)
+elseif((CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+	message("-- Setting clang options")
+
+	set(WARNINGS "-Wall -Wextra -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls")
+	set(OSX_SUPPRESSIONS "-Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wno-shorten-64-to-32 -Wno-reorder -Wno-unused-local-typedefs")
+	set(WARNINGS "${WARNINGS} ${OSX_SUPPRESSIONS}")
+
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-return-type-c-linkage -Wno-unneeded-internal-declaration")
+	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
+	if (BUILD_SHARED_LIBS)
+		add_definitions(-DBOOST_LOG_DYN_LINK)
+	endif()
+	add_definitions(-D_TURN_OFF_PLATFORM_STRING)
 else()
   message("-- Unknown compiler, success is doubtful.")
 endif()
@@ -80,7 +114,7 @@ add_subdirectory(src)
 
 if(BUILD_TESTS)
   set(AZURESTORAGE_LIBRARY_TEST azurestoragetest)
-  add_subdirectory(tests) 
+  add_subdirectory(tests)
 endif()
 
 if(BUILD_SAMPLES)

--- a/Microsoft.WindowsAzure.Storage/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/CMakeLists.txt
@@ -15,25 +15,33 @@ option(BUILD_SAMPLES "Build sample codes" OFF)
 if(UNIX)
   find_package(Boost REQUIRED COMPONENTS log log_setup random system thread locale regex filesystem chrono date_time)
   find_package(Threads REQUIRED)
-  if(APPLE)
-	 message(WARNING "On OSX you must specify OPENSSL_ROOT_DIR, it is currently ${OPENSSL_ROOT_DIR}")
+  if(APPLE AND NOT OPENSSL_ROOT_DIR)
+    # Prefer a homebrew version of OpenSSL over the one in /usr/lib
+    file(GLOB OPENSSL_ROOT_DIR /usr/local/Cellar/openssl/*)
 
-	  # this isn't ideal because it requires the user to set OPENSSL_ROOT_DIR rather than being automated
-	  set(OPENSSL_FOUND 1)
-	  set(OPENSSL_INCLUDE_DIR "${OPENSSL_ROOT_DIR}/include")
-	  set(OPENSSL_LIBRARIES
-		"${OPENSSL_ROOT_DIR}/lib/libcrypto.dylib"
-		"${OPENSSL_ROOT_DIR}/lib/libssl.dylib"
-		)
+	# Prefer the latest (make the latest one first)
+    list(REVERSE OPENSSL_ROOT_DIR)
 
-		message(WARNING "On OSX you must specify GETTEXT_LIB_DIR, it is currently ${GETTEXT_LIB_DIR}")
-		set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${GETTEXT_LIB_DIR}")
+	# There is a dependency chain Libxml++ -> glibmm -> gobject -> glib -> lintl, however, for some reason,
+	# with homebrew at least, the -L for where lintl resides is left out. So, we try to find it where homebrew
+	# would put it, or allow the user to specify it
+	if(NOT GETTEXT_LIB_DIR)
+		message(WARNING "No GETTEXT_LIB_DIR specified, assuming: /usr/local/opt/gettext/lib")
+		set(GETTEXT_LIB_DIR "/usr/local/opt/gettext/lib")
+	endif()
+	# If we didn't find it where homebrew would put it, and it hasn't been specified, then we have to throw an error
+	if(NOT IS_DIRECTORY "${GETTEXT_LIB_DIR}")
+		message(ERROR "We couldn't find your gettext lib directory (${GETTEXT_LIB_DIR}). Please re-run cmake with -DGETTEXT_LIB_DIR=<your gettext lib dir>. This is usually where libintl.a and libintl.dylib reside.")
+	endif()
 
-		
-
-  else()
-  	find_package(OpenSSL REQUIRED)
+	# if we actually have a GETTEXT_LIB_DIR we add the linker flag for it
+	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${GETTEXT_LIB_DIR}")
   endif()
+
+  set(_OPENSSL_VERSION "")
+  find_package(OpenSSL 1.0.0 REQUIRED)
+
+
   find_package(Glibmm REQUIRED)
   find_package(LibXML++ REQUIRED)
   find_package(UUID REQUIRED)
@@ -100,6 +108,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/Binaries)
 
 set(AZURESTORAGE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/includes)
 set(AZURESTORAGE_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/includes ${CASABLANCA_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIRS} ${LibXML++_INCLUDE_DIRS} ${UUID_INCLUDE_DIRS} ${Glibmm_INCLUDE_DIRS})
+
 
 set(AZURESTORAGE_LIBRARY azurestorage)
 set(AZURESTORAGE_LIBRARIES ${AZURESTORAGE_LIBRARY} ${CASABLANCA_LIBRARIES} ${Boost_LIBRARIES} ${Boost_FRAMEWORK} ${OPENSSL_LIBRARIES} ${LibXML++_LIBRARIES} ${UUID_LIBRARIES} ${Glibmm_LIBRARIES})

--- a/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories(${Boost_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
 include_directories(${AZURESTORAGE_INCLUDE_DIRS})
 
 # THE ORDER OF FILES IS VERY /VERY/ IMPORTANT
@@ -54,6 +55,7 @@ endif()
 if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
 
 add_library(${AZURESTORAGE_LIBRARY} ${SOURCES})
 
@@ -71,4 +73,3 @@ if(UNIX)
     ARCHIVE DESTINATION lib
     )
 endif()
-

--- a/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
@@ -55,7 +55,11 @@ endif()
 if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
 endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
+if (APPLE)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
+else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
+endif()
 
 add_library(${AZURESTORAGE_LIBRARY} ${SOURCES})
 

--- a/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 if (APPLE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
 else()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
 add_library(${AZURESTORAGE_LIBRARY} ${SOURCES})

--- a/README.md
+++ b/README.md
@@ -140,10 +140,16 @@ Please note the current build script is only tested on Ubuntu 14.04. Please upda
 Install dependecies with homebrew:
 
 ```
-brew install glibmm libxml++ libsigc++ ossp-uuid gettext openssl
+brew install libxml++ ossp-uuid openssl
 ```
 
-As mentioned above, the Azure Storage Client Library for C++ depends on Casablanca. Follow [these instructions](https://github.com/Microsoft/cpprestsdk/wiki/How-to-build-for-Mac-OS-X) to compile it. Current version of the library depends on Casablanca version 2.8.0.
+As mentioned above, the Azure Storage Client Library for C++ depends on Casablanca.
+If you are using homebrew you can install it from there:
+```
+brew install cpprestsdk
+```
+
+Otherwise, you may need to build it. Follow [these instructions](https://github.com/Microsoft/cpprestsdk/wiki/How-to-build-for-Mac-OS-X) to compile it. Current version of the library depends on Casablanca version 2.8.0.
 
 Once this is complete, then:
 
@@ -152,19 +158,36 @@ Once this is complete, then:
 git clone https://github.com/Azure/azure-storage-cpp.git
 ```
 The project is cloned to a folder called `azure-storage-cpp`. Always use the master branch, which contains the latest release.
-- Install additional dependencies:
-```bash
-sudo apt-get install libxml++2.6-dev libxml++2.6-doc uuid-dev
-```
-- Build the SDK for Release:
+
+**Some notes about building**:
+- If you're using homebrew, there seems to be an issue with the pkg-config files, which means that, by default, a -L flag to tell the linker where libintl lives is left out. We've accounted for this in our CMAKE file, by looking in the usual directory that homebrew puts those libs. If you are not using homebrew, you will get an error stating that you need to tell us where those libs live.
+- Similarly, for openssl, you don't want to use the version that comes with OSX, it is old. We've accounted for this in the CMAKE script by setting the search paths to where homebrew puts openssl, so if you're not using homebrew you'll need to tell us where a more recent version of openssl lives.
+
+- Build the SDK for Release if you are using hombrew:
 ```bash
 cd azure-storage-cpp/Microsoft.WIndowsAzure.Storage
 mkdir build.release
 cd build.release
-CASABLANCA_DIR=<path to Casablanca> cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=<path to openssl> -DGETTEXT_LIB_DIR=<path to gettext lib dir>
+cmake .. -DCMAKE_BUILD_TYPE=Release
 make
 ```
-In the above command, replace `<path to Casablanca>` to point to your local installation of Casablanca. <path to openssl> to your local openssl, it is recommended not to use the version that comes with OSX, rather use one from Homebrew or the like. <path to gettext lib dir> is similar, although you go all the way to the lib dir. For example, if the file `libcpprest.so` exists at location `~/Github/Casablanca/cpprestsdk/Release/build.release/Binaries/libcpprest.so`, and you've installed the dependencies through homebrew then your `cmake` command should be:
+
+- OR, Build the SDK for Release if you are not using homebrew
+
+```bash
+cd azure-storage-cpp/Microsoft.WindowsAzure.Storage
+mkdir build.release
+cd build.release
+CASABLANCA_DIR=<path to casablanca> cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=<path to openssl> -DGETTEXT_LIB_DIR=<path to gettext lib dir>
+make
+```
+
+In the above command, replace:
+- `<path to Casablanca>` to point to your local installation of Casablanca. For example, if the file `libcpprest.so` exists at location `~/Github/Casablanca/cpprestsdk/Release/build.release/Binaries/libcpprest.dylib`, then <path to casablanca> should be `~/Github/Casablanca/cpprestsdk`
+- `<path to openssl>` to your local openssl, it is recommended not to use the version that comes with OSX, rather use one from Homebrew or the like. This should be the path that contains the `lib` and `include` directories
+- `<path to gettext lib dir>` is the directory which contains `libintl.dylib`
+
+For example you might use:
 ```bash
 CASABLANCA_DIR=~/Github/Casablanca/cpprestsdk cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DGETTEXT_LIB_DIR=/usr/local/opt/gettext/lib
 ```

--- a/README.md
+++ b/README.md
@@ -193,7 +193,22 @@ CASABLANCA_DIR=~/Github/Casablanca/cpprestsdk cmake .. -DCMAKE_BUILD_TYPE=Releas
 ```
 The library is generated under `azure-storage-cpp/Microsoft.WindowsAzure.Storage/build.release/Binaries/`.
 
-*As yet the unit tests don't build, because cmake won't find UnitTest++ even though it is installed via Homebrew*
+To build and run unit tests:
+- Install UnitTest++ library:
+```bash
+brew install unittest-cpp
+```
+- Build the test code:
+```bash
+cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
+make
+```
+- Run unit tests
+```bash
+cd Binaries
+vi test_configurations.json # modify test config file to include your storage account credentials
+./azurestoragetest
+```
 
 # Learn More
 - [Microsoft Azure Storage Client Library for C++ v2.0.0](documentation/Microsoft%20Azure%20Storage%20Client%20Library%20for%20C%2B%2B%202.0.0.md)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Azure Storage Client Library for C++ allows you to build applications agains
 
 # Getting started
 
-For the best development experience, we recommend that developers use the official Microsoft NuGet packages for libraries. NuGet packages are regularly updated with new functionality and hotfixes. 
+For the best development experience, we recommend that developers use the official Microsoft NuGet packages for libraries. NuGet packages are regularly updated with new functionality and hotfixes.
 Download the [NuGet Package](http://www.nuget.org/packages/wastorage).
 
 ## Requirements
@@ -33,7 +33,7 @@ We gladly accept community contributions.
 
 - **Issues:** Report bugs on the [Issues page](https://github.com/Azure/azure-storage-cpp/issues) in GitHub.
 - **Forums:** Communicate with the Azure Storage development team on the [Azure Storage Forum](https://social.msdn.microsoft.com/Forums/azure/en-US/home?forum=windowsazuredata) or [StackOverflow](http://stackoverflow.com/questions/tagged/azure).
-- **Source Code Contributions:** Please follow the [contribution guidelines for Azure open source](http://azure.github.io/guidelines/) for instructions about contributing to the source project. 
+- **Source Code Contributions:** Please follow the [contribution guidelines for Azure open source](http://azure.github.io/guidelines/) for instructions about contributing to the source project.
 
 For general suggestions about Azure, use our [Azure feedback forum](http://feedback.azure.com/forums/34192--general-feedback).
 
@@ -133,6 +133,44 @@ cd Binaries
 
 Please note the current build script is only tested on Ubuntu 14.04. Please update the script accordingly for other distributions.
 
+## Getting Started on OSX
+
+*Note that OSX is not officially supported yet, but it has been seen to work, YMMV. This build has been tested to work when the dependencies are installed via homebrew, YMMV if using FINK or MacPorts*
+
+Install dependecies with homebrew:
+
+```
+brew install glibmm libxml++ libsigc++ ossp-uuid gettext openssl
+```
+
+As mentioned above, the Azure Storage Client Library for C++ depends on Casablanca. Follow [these instructions](https://github.com/Microsoft/cpprestsdk/wiki/How-to-build-for-Mac-OS-X) to compile it. Current version of the library depends on Casablanca version 2.8.0.
+
+Once this is complete, then:
+
+- Clone the project using git:
+```bash
+git clone https://github.com/Azure/azure-storage-cpp.git
+```
+The project is cloned to a folder called `azure-storage-cpp`. Always use the master branch, which contains the latest release.
+- Install additional dependencies:
+```bash
+sudo apt-get install libxml++2.6-dev libxml++2.6-doc uuid-dev
+```
+- Build the SDK for Release:
+```bash
+cd azure-storage-cpp/Microsoft.WIndowsAzure.Storage
+mkdir build.release
+cd build.release
+CASABLANCA_DIR=<path to Casablanca> cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=<path to openssl> -DGETTEXT_LIB_DIR=<path to gettext lib dir>
+make
+```
+In the above command, replace `<path to Casablanca>` to point to your local installation of Casablanca. <path to openssl> to your local openssl, it is recommended not to use the version that comes with OSX, rather use one from Homebrew or the like. <path to gettext lib dir> is similar, although you go all the way to the lib dir. For example, if the file `libcpprest.so` exists at location `~/Github/Casablanca/cpprestsdk/Release/build.release/Binaries/libcpprest.so`, and you've installed the dependencies through homebrew then your `cmake` command should be:
+```bash
+CASABLANCA_DIR=~/Github/Casablanca/cpprestsdk cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DGETTEXT_LIB_DIR=/usr/local/opt/gettext/lib
+```
+The library is generated under `azure-storage-cpp/Microsoft.WindowsAzure.Storage/build.release/Binaries/`.
+
+*As yet the unit tests don't build, because cmake won't find UnitTest++ even though it is installed via Homebrew*
 
 # Learn More
 - [Microsoft Azure Storage Client Library for C++ v2.0.0](documentation/Microsoft%20Azure%20Storage%20Client%20Library%20for%20C%2B%2B%202.0.0.md)


### PR DESCRIPTION
Refers to issue #27 .

This is a replacement for a previous PR.

Further tidied CMake files as per Han Zhu's requests  …
Managed to resolve the CMAKE issue around finding OpenSSL, so now
it uses the same method as Casablanca, and doesn't require homebrew
users to specify OPENSSL_ROOT_DIR. The readme explains what to set it
to for non-homebrew users (eg Fink, or Macports)

Tidied up the process for including the -L for gettext, which is
required by libintl, which is part of the dependency chain for
libxml++, but isn't handled very well by pkg-config for some reason. 

@hanzhumsft this is were the need for gettext comes in. The dependency graph is something like libxml++ -> glibmm -> gobject -> glib-2.0 -> gettext (which is libintl and friends)

Again we assume the path for homebrew, (raising messages if we can't)
find it, and the readme describes how non-homebrew users can point
to their installation if needed.

in src/CMakeLists.txt, put an APPLE conditional around adding the warnings
variable to the CXX flags

Tidided up the readme section for OSX so that it drops some of the
linux bits that were copy pasted. Made clearer instructions for homebrew
users vs non-homebrew users. Removed some of the brew packages that the
user needs to install as they will be installed as dependencies if needed.