### PR TITLE
Bug fix for copy blob from a cloud_blob object. Add additional test case.

### DIFF
--- a/Microsoft.WindowsAzure.Storage/src/cloud_blob.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/cloud_blob.cpp
@@ -610,7 +610,7 @@ namespace azure { namespace storage {
     pplx::task<utility::string_t> cloud_blob::start_copy_async(const cloud_blob& source, const access_condition& source_condition, const access_condition& destination_condition, const blob_request_options& options, operation_context context)
     {
         web::http::uri raw_source_uri = source.snapshot_qualified_uri().primary_uri();
-        web::http::uri source_uri = service_client().credentials().transform_uri(raw_source_uri);
+        web::http::uri source_uri = source.service_client().credentials().transform_uri(raw_source_uri);
 
         return start_copy_async(source_uri, source_condition, destination_condition, options, context);
     }


### PR DESCRIPTION
[Bug]In blob copy, wrongly used destination's credentials to sign source uri. 
[Fix] 
     1. use source's credentials to sign uri.
[Test case]
    1. add a test case on blob copy with sas token.