### PR TITLE
Add support for MSVC/WIN32 to CMake. Add additional names for finding cpprestsdk.

### DIFF
--- a/Microsoft.WindowsAzure.Storage/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/CMakeLists.txt
@@ -10,8 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 option(BUILD_TESTS "Build test codes" OFF)
 option(BUILD_SAMPLES "Build sample codes" OFF)
+option(BUILD_SHARED_LIBS "Build shared Libraries." ON)
 
 # Platform (not compiler) specific settings
+find_package(Casablanca REQUIRED)
 if(UNIX)
   find_package(Boost REQUIRED COMPONENTS log log_setup random system thread locale regex filesystem chrono date_time)
   find_package(Threads REQUIRED)
@@ -19,23 +21,23 @@ if(UNIX)
     # Prefer a homebrew version of OpenSSL over the one in /usr/lib
     file(GLOB OPENSSL_ROOT_DIR /usr/local/Cellar/openssl/*)
 
-	# Prefer the latest (make the latest one first)
+    # Prefer the latest (make the latest one first)
     list(REVERSE OPENSSL_ROOT_DIR)
 
-	# There is a dependency chain Libxml++ -> glibmm -> gobject -> glib -> lintl, however, for some reason,
-	# with homebrew at least, the -L for where lintl resides is left out. So, we try to find it where homebrew
-	# would put it, or allow the user to specify it
-	if(NOT GETTEXT_LIB_DIR)
-		message(WARNING "No GETTEXT_LIB_DIR specified, assuming: /usr/local/opt/gettext/lib")
-		set(GETTEXT_LIB_DIR "/usr/local/opt/gettext/lib")
-	endif()
-	# If we didn't find it where homebrew would put it, and it hasn't been specified, then we have to throw an error
-	if(NOT IS_DIRECTORY "${GETTEXT_LIB_DIR}")
-		message(ERROR "We couldn't find your gettext lib directory (${GETTEXT_LIB_DIR}). Please re-run cmake with -DGETTEXT_LIB_DIR=<your gettext lib dir>. This is usually where libintl.a and libintl.dylib reside.")
-	endif()
+    # There is a dependency chain Libxml++ -> glibmm -> gobject -> glib -> lintl, however, for some reason,
+    # with homebrew at least, the -L for where lintl resides is left out. So, we try to find it where homebrew
+    # would put it, or allow the user to specify it
+    if(NOT GETTEXT_LIB_DIR)
+      message(WARNING "No GETTEXT_LIB_DIR specified, assuming: /usr/local/opt/gettext/lib")
+      set(GETTEXT_LIB_DIR "/usr/local/opt/gettext/lib")
+    endif()
+    # If we didn't find it where homebrew would put it, and it hasn't been specified, then we have to throw an error
+    if(NOT IS_DIRECTORY "${GETTEXT_LIB_DIR}")
+      message(ERROR "We couldn't find your gettext lib directory (${GETTEXT_LIB_DIR}). Please re-run cmake with -DGETTEXT_LIB_DIR=<your gettext lib dir>. This is usually where libintl.a and libintl.dylib reside.")
+    endif()
 
-	# if we actually have a GETTEXT_LIB_DIR we add the linker flag for it
-	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${GETTEXT_LIB_DIR}")
+    # if we actually have a GETTEXT_LIB_DIR we add the linker flag for it
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -L${GETTEXT_LIB_DIR}")
   endif()
 
   set(_OPENSSL_VERSION "")
@@ -45,26 +47,24 @@ if(UNIX)
   find_package(Glibmm REQUIRED)
   find_package(LibXML++ REQUIRED)
   find_package(UUID REQUIRED)
-  find_package(Casablanca REQUIRED)
 
-  if(BUILD_TESTS)
-    find_package(UnitTest++ REQUIRED)
-  endif()
-
-  option(BUILD_SHARED_LIBS "Build shared Libraries." ON)
-
-  file(GLOB WAS_HEADERS includes/was/*.h)
-  install(FILES ${WAS_HEADERS} DESTINATION include/was)
-  file(GLOB WASCORE_HEADERS includes/wascore/*.h)
-  install(FILES ${WASCORE_HEADERS} DESTINATION include/wascore)
-  file(GLOB WASCORE_DATA includes/wascore/*.dat)
-  install(FILES ${WASCORE_DATA} DESTINATION include/wascore)
 else()
   message("-- Unsupported Build Platform.")
 endif()
 
+file(GLOB WAS_HEADERS includes/was/*.h)
+install(FILES ${WAS_HEADERS} DESTINATION include/was)
+file(GLOB WASCORE_HEADERS includes/wascore/*.h)
+install(FILES ${WASCORE_HEADERS} DESTINATION include/wascore)
+file(GLOB WASCORE_DATA includes/wascore/*.dat)
+install(FILES ${WASCORE_DATA} DESTINATION include/wascore)
+
+if(BUILD_TESTS)
+  find_package(UnitTest++ REQUIRED)
+endif()
+
 # Compiler (not platform) specific settings
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   message("-- Setting gcc options")
 
   set(WARNINGS "-Wall -Wextra -Wunused-parameter -Wcast-align -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls -Wunreachable-code")
@@ -81,22 +81,23 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
     add_definitions(-DBOOST_LOG_DYN_LINK)
   endif()
   add_definitions(-D_TURN_OFF_PLATFORM_STRING)
-elseif((CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
-	message("-- Setting clang options")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  message("-- Setting clang options")
 
-	set(WARNINGS "-Wall -Wextra -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls")
-	set(OSX_SUPPRESSIONS "-Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wno-shorten-64-to-32 -Wno-reorder -Wno-unused-local-typedefs")
-	set(WARNINGS "${WARNINGS} ${OSX_SUPPRESSIONS}")
+  set(WARNINGS "-Wall -Wextra -Wcast-qual -Wconversion -Wformat=2 -Winit-self -Winvalid-pch -Wmissing-format-attribute -Wmissing-include-dirs -Wpacked -Wredundant-decls")
+  set(OSX_SUPPRESSIONS "-Wno-overloaded-virtual -Wno-sign-conversion -Wno-deprecated -Wno-unknown-pragmas -Wno-reorder -Wno-char-subscripts -Wno-switch -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated -Wno-unused-value -Wno-unknown-warning-option -Wno-return-type-c-linkage -Wno-unused-function -Wno-sign-compare -Wno-shorten-64-to-32 -Wno-reorder -Wno-unused-local-typedefs")
+  set(WARNINGS "${WARNINGS} ${OSX_SUPPRESSIONS}")
 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-return-type-c-linkage -Wno-unneeded-internal-declaration")
-	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
-	set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-return-type-c-linkage -Wno-unneeded-internal-declaration")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+  set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
-	if (BUILD_SHARED_LIBS)
-		add_definitions(-DBOOST_LOG_DYN_LINK)
-	endif()
-	add_definitions(-D_TURN_OFF_PLATFORM_STRING)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fno-strict-aliasing")
+  if (BUILD_SHARED_LIBS)
+    add_definitions(-DBOOST_LOG_DYN_LINK)
+  endif()
+  add_definitions(-D_TURN_OFF_PLATFORM_STRING)
+elseif(MSVC)
 else()
   message("-- Unknown compiler, success is doubtful.")
 endif()

--- a/Microsoft.WindowsAzure.Storage/cmake/Modules/FindCasablanca.cmake
+++ b/Microsoft.WindowsAzure.Storage/cmake/Modules/FindCasablanca.cmake
@@ -27,6 +27,8 @@ find_path(CASABLANCA_INCLUDE_DIR
 find_library(CASABLANCA_LIBRARY
   NAMES 
     cpprest
+    cpprest_2_9
+    cpprest_2_8
   PATHS 
     ${CASABLANCA_PKGCONF_LIBRARY_DIRS}
     ${CASABLANCA_DIR}

--- a/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
+++ b/Microsoft.WindowsAzure.Storage/src/CMakeLists.txt
@@ -2,76 +2,92 @@ include_directories(${Boost_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
 include_directories(${AZURESTORAGE_INCLUDE_DIRS})
 
 # THE ORDER OF FILES IS VERY /VERY/ IMPORTANT
-if(UNIX)
-  set(SOURCES
-     xmlhelpers.cpp
-     response_parsers.cpp
-     request_result.cpp
-     request_factory.cpp
-     protocol_xml.cpp
-     navigation.cpp
-     async_semaphore.cpp
-     util.cpp
-     table_request_factory.cpp
-     table_response_parsers.cpp
-     table_query.cpp
-     entity_property.cpp
-     shared_access_signature.cpp
-     retry_policies.cpp
-     resources.cpp
-     queue_request_factory.cpp
-     file_request_factory.cpp
-     file_response_parsers.cpp
-     protocol_json.cpp
-     operation_context.cpp
-     mime_multipart_helper.cpp
-     logging.cpp
-     hashing.cpp
-     constants.cpp
-     streams.cpp
-     cloud_file_ostreambuf.cpp
-     cloud_file.cpp
-     cloud_file_directory.cpp
-     cloud_file_share.cpp
-     cloud_file_client.cpp
-     cloud_table_client.cpp
-     cloud_table.cpp
-     cloud_storage_account.cpp
-     cloud_queue_message.cpp
-     cloud_queue_client.cpp
-     cloud_queue.cpp
-     cloud_page_blob.cpp
-     cloud_core.cpp
-     cloud_client.cpp
-     cloud_block_blob.cpp
-     cloud_blob_directory.cpp
-     cloud_blob_container.cpp
-     cloud_blob_shared.cpp
-     cloud_blob_ostreambuf.cpp
-     cloud_blob_istreambuf.cpp
-     cloud_blob_client.cpp
-     cloud_blob.cpp
-     cloud_append_blob.cpp
-     blob_response_parsers.cpp
-     blob_request_factory.cpp
-     basic_types.cpp
-     authentication.cpp
-     cloud_common.cpp
-    )
+set(SOURCES
+    xmlhelpers.cpp
+    response_parsers.cpp
+    request_result.cpp
+    request_factory.cpp
+    protocol_xml.cpp
+    navigation.cpp
+    async_semaphore.cpp
+    util.cpp
+    table_request_factory.cpp
+    table_response_parsers.cpp
+    table_query.cpp
+    entity_property.cpp
+    shared_access_signature.cpp
+    retry_policies.cpp
+    resources.cpp
+    queue_request_factory.cpp
+    file_request_factory.cpp
+    file_response_parsers.cpp
+    protocol_json.cpp
+    operation_context.cpp
+    mime_multipart_helper.cpp
+    logging.cpp
+    hashing.cpp
+    constants.cpp
+    streams.cpp
+    cloud_file_ostreambuf.cpp
+    cloud_file.cpp
+    cloud_file_directory.cpp
+    cloud_file_share.cpp
+    cloud_file_client.cpp
+    cloud_table_client.cpp
+    cloud_table.cpp
+    cloud_storage_account.cpp
+    cloud_queue_message.cpp
+    cloud_queue_client.cpp
+    cloud_queue.cpp
+    cloud_page_blob.cpp
+    cloud_core.cpp
+    cloud_client.cpp
+    cloud_block_blob.cpp
+    cloud_blob_directory.cpp
+    cloud_blob_container.cpp
+    cloud_blob_shared.cpp
+    cloud_blob_ostreambuf.cpp
+    cloud_blob_istreambuf.cpp
+    cloud_blob_client.cpp
+    cloud_blob.cpp
+    cloud_append_blob.cpp
+    blob_response_parsers.cpp
+    blob_request_factory.cpp
+    basic_types.cpp
+    authentication.cpp
+    cloud_common.cpp
+  )
+
+if(BUILD_SHARED_LIBS)
+  add_definitions(-DWASTORAGE_DLL -D_USRDLL)
 endif()
 
-if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")
-endif()
-if (APPLE)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
+if(MSVC)
+  add_definitions(-DUNICODE)
+  add_compile_options(/we4100 /Yustdafx.h /Zm200 /bigobj)
+  set_source_files_properties(stdafx.cpp PROPERTIES COMPILE_FLAGS "/Ycstdafx.h")
+
+  if (NOT CMAKE_GENERATOR MATCHES "Visual Studio .*")
+    set_property(SOURCE stdafx.cpp APPEND PROPERTY OBJECT_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+    set_property(SOURCE ${SOURCES} APPEND PROPERTY OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/stdafx.pch")
+  endif()
+
+  list(APPEND SOURCES stdafx.cpp)
 else()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fprofile-arcs -ftest-coverage")
+endif()
+
+if (APPLE)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
 endif()
 
 add_library(${AZURESTORAGE_LIBRARY} ${SOURCES})
 
 target_link_libraries(${AZURESTORAGE_LIBRARIES})
+
+if(WIN32)
+  target_link_libraries(${AZURESTORAGE_LIBRARY} Ws2_32.lib rpcrt4.lib xmllite.lib bcrypt.lib)
+endif()
 
 # Portions specific to azure storage binary versioning and installation.
 if(UNIX)
@@ -79,9 +95,11 @@ if(UNIX)
     SOVERSION ${AZURESTORAGE_VERSION_MAJOR}
     VERSION ${AZURESTORAGE_VERSION_MAJOR}.${AZURESTORAGE_VERSION_MINOR})
 
-  install(
-    TARGETS ${AZURESTORAGE_LIBRARY}
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    )
 endif()
+
+install(
+  TARGETS ${AZURESTORAGE_LIBRARY}
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  )


### PR DESCRIPTION
This pull request adds support for building DLLs using VS 2015 against Windows desktop. It should theoretically work for VS 2017 and static libraries, but I haven't tried those combinations.

During the commit, my editor changed some mixed tabs/spaces to just spaces (matching the rest of the file). If it's difficult to review because of this, the git command line invocation
```
git diff c9db25d..c9db25d~ --ignore-space-change
```
helps to clean things up quite a bit.

[edit: I had a typo while performing the merge to dev]