### PR TITLE
Fix for issue #152

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/wascore/executor.h
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/executor.h
@@ -638,15 +638,17 @@ namespace azure { namespace storage { namespace core {
                         instance->m_hash_provider.close();
                         instance->m_is_hashing_started = false;
 
+                        utility::size64_t bytes_downloaded = 0;
                         if (instance->m_response_streambuf)
                         {
-                            instance->m_total_downloaded += instance->m_response_streambuf.total_written();
+                            bytes_downloaded = instance->m_response_streambuf.total_written();
+                            instance->m_total_downloaded += bytes_downloaded;
                         }
 
                         // Try to recover the request. If it cannot be recovered, it cannot be retried
                         // even if the retry policy allowed for a retry.
                         if (instance->m_command->m_recover_request &&
-                            !instance->m_command->m_recover_request(instance->m_total_downloaded, instance->m_context))
+                            !instance->m_command->m_recover_request(bytes_downloaded, instance->m_context))
                         {
                             if (logger::instance().should_log(instance->m_context, client_log_level::log_level_error))
                             {

--- a/Microsoft.WindowsAzure.Storage/src/cloud_blob.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/cloud_blob.cpp
@@ -455,13 +455,13 @@ namespace azure { namespace storage {
         command->set_location_mode(core::command_location_mode::primary_or_secondary);
         command->set_destination_stream(target);
         command->set_calculate_response_body_md5(!modified_options.disable_content_md5_validation());
-        command->set_recover_request([target, download_info](utility::size64_t total_written_to_destination_stream, operation_context context) -> bool
+        command->set_recover_request([target, download_info](utility::size64_t bytes_written_to_destination_stream, operation_context context) -> bool
         {
             if (download_info->m_reset_target)
             {
                 download_info->m_total_written_to_destination_stream = 0;
 
-                if (total_written_to_destination_stream > 0)
+                if (bytes_written_to_destination_stream > 0)
                 {
                     if (!target.can_seek())
                     {
@@ -475,7 +475,7 @@ namespace azure { namespace storage {
             }
             else
             {
-                download_info->m_total_written_to_destination_stream = total_written_to_destination_stream;
+                download_info->m_total_written_to_destination_stream += bytes_written_to_destination_stream;
             }
 
             return target.is_open();

--- a/Microsoft.WindowsAzure.Storage/src/cloud_file.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/cloud_file.cpp
@@ -460,13 +460,13 @@ namespace azure { namespace storage {
         command->set_location_mode(core::command_location_mode::primary_or_secondary);
         command->set_destination_stream(target);
         command->set_calculate_response_body_md5(!modified_options.disable_content_md5_validation());
-        command->set_recover_request([target, download_info](utility::size64_t total_written_to_destination_stream, operation_context context) -> bool
+        command->set_recover_request([target, download_info](utility::size64_t bytes_written_to_destination_stream, operation_context context) -> bool
         {
             if (download_info->m_reset_target)
             {
                 download_info->m_total_written_to_destination_stream = 0;
 
-                if (total_written_to_destination_stream > 0)
+                if (bytes_written_to_destination_stream > 0)
                 {
                     if (!target.can_seek())
                     {
@@ -480,7 +480,7 @@ namespace azure { namespace storage {
             }
             else
             {
-                download_info->m_total_written_to_destination_stream = total_written_to_destination_stream;
+                download_info->m_total_written_to_destination_stream += bytes_written_to_destination_stream;
             }
 
             return target.is_open();


### PR DESCRIPTION
Update execute_async to pass the number of bytes written to the destination stream in the current execution attempt to the recover_request callback.

In download_single_range_to_stream_async, store the total number of bytes written to the destination stream in download_info.m_total_written_to_destination_stream across all retries.