### PR TITLE
Bug fixes for 4.0.0

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/wascore/constants.dat
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/constants.dat
@@ -420,6 +420,7 @@ DAT(error_free_uuid, "An error occurred freeing the UUID string.")
 DAT(error_parse_uuid, "An error occurred parsing the UUID.")
 
 DAT(error_empty_metadata_value, "The metadata value cannot be empty or consist entirely of whitespace.")
+DAT(error_empty_whitespace_metadata_name, "The metadata name cannot contain any whitespaces or be empty.")
 DAT(error_hash_on_closed_streambuf, "Hash is calculated when the streambuf is closed.")
 DAT(error_invalid_settings_form, "Settings must be of the form \"name=value\".")
 

--- a/Microsoft.WindowsAzure.Storage/includes/wascore/constants.dat
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/constants.dat
@@ -386,6 +386,7 @@ DAT(error_storage_uri_empty, "Primary or secondary location URI must be supplied
 DAT(error_storage_uri_mismatch, "Primary and secondary location URIs must point to the same resource.")
 
 DAT(error_empty_batch_operation, "The batch operation cannot be empty.")
+DAT(error_batch_size_not_match_response, "The received batch result size does not match the size of the batch operations sent to the server.")
 DAT(error_batch_operation_partition_key_mismatch, "The batch operation cannot contain entities with different partition keys.")
 DAT(error_batch_operation_retrieve_count, "The batch operation cannot contain more than one retrieve operation.")
 DAT(error_batch_operation_retrieve_mix, "The batch operation cannot contain any other operations when it contains a retrieve operation.")

--- a/Microsoft.WindowsAzure.Storage/includes/wascore/constants.dat
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/constants.dat
@@ -362,6 +362,7 @@ DAT(error_blob_type_mismatch, "Blob type of the blob reference doesn't match blo
 DAT(error_closed_stream, "Cannot access a closed stream.")
 DAT(error_lease_id_on_source, "A lease condition cannot be specified on the source of a copy.")
 DAT(error_incorrect_length, "Incorrect number of bytes received.")
+DAT(error_xml_not_complete, "The XML parsed is not complete.")
 DAT(error_blob_over_max_block_limit, "The total blocks required for this upload exceeds the maximum block limit. Please increase the block size if applicable and ensure the Blob size is not greater than the maximum Blob size limit.")
 DAT(error_md5_mismatch, "Calculated MD5 does not match existing property.")
 DAT(error_missing_md5, "MD5 does not exist. If you do not want to force validation, please disable use_transactional_md5.")

--- a/Microsoft.WindowsAzure.Storage/includes/wascore/protocol_xml.h
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/protocol_xml.h
@@ -21,6 +21,7 @@
 #include "was/blob.h"
 #include "was/queue.h"
 #include "was/file.h"
+#include "wascore/protocol.h"
 #include "wascore/xmlhelpers.h"
 
 #pragma push_macro("max")
@@ -112,13 +113,21 @@ namespace azure { namespace storage { namespace protocol {
 
         std::vector<cloud_blob_container_list_item> move_items()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_items);
         }
 
         utility::string_t move_next_marker()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_next_marker);
         }
 
@@ -223,19 +232,31 @@ namespace azure { namespace storage { namespace protocol {
 
         std::vector<cloud_blob_list_item> move_blob_items()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_blob_items);
         }
 
         std::vector<cloud_blob_prefix_list_item> move_blob_prefix_items()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_blob_prefix_items);
         }
 
         utility::string_t move_next_marker()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_next_marker);
         }
 
@@ -270,7 +291,11 @@ namespace azure { namespace storage { namespace protocol {
         // Extracts the result. This method can only be called once on this reader
         std::vector<page_range> move_result()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_page_list);
         }
 
@@ -296,7 +321,11 @@ namespace azure { namespace storage { namespace protocol {
         // Extracts the result. This method can only be called once on this reader
         std::vector<page_diff_range> move_result()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_page_list);
         }
 
@@ -322,7 +351,11 @@ namespace azure { namespace storage { namespace protocol {
         // Extracts the result. This method can only be called once on this reader
         std::vector<block_list_item> move_result()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_block_list);
         }
 
@@ -364,7 +397,11 @@ namespace azure { namespace storage { namespace protocol {
 
         shared_access_policies<Policy> move_policies()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_policies);
         }
 
@@ -491,13 +528,21 @@ namespace azure { namespace storage { namespace protocol {
 
         std::vector<cloud_queue_list_item> move_items()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_items);
         }
 
         utility::string_t move_next_marker()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_next_marker);
         }
 
@@ -579,7 +624,12 @@ namespace azure { namespace storage { namespace protocol {
 
         std::vector<cloud_message_list_item> move_items()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                // This is not a retryable exception because Get operation for messages changes server content.
+                throw storage_exception(protocol::error_xml_not_complete, false);
+            }
             return std::move(m_items);
         }
 
@@ -658,7 +708,11 @@ namespace azure { namespace storage { namespace protocol {
 
         int32_t get()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return m_quota;
         }
 
@@ -682,13 +736,21 @@ namespace azure { namespace storage { namespace protocol {
 
         std::vector<cloud_file_share_list_item> move_items()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_items);
         }
 
         utility::string_t move_next_marker()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_next_marker);
         }
 
@@ -719,13 +781,21 @@ namespace azure { namespace storage { namespace protocol {
 
         std::vector<list_file_and_directory_item> move_items()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_items);
         }
 
         utility::string_t move_next_marker()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_next_marker);
         }
 
@@ -758,7 +828,11 @@ namespace azure { namespace storage { namespace protocol {
         // Extracts the result. This method can only be called once on this reader
         std::vector<file_range> move_result()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_range_list);
         }
 
@@ -783,7 +857,11 @@ namespace azure { namespace storage { namespace protocol {
 
         service_properties move_properties()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_service_properties);
         }
 
@@ -833,7 +911,11 @@ namespace azure { namespace storage { namespace protocol {
 
         service_stats move_stats()
         {
-            parse();
+            auto result = parse();
+            if (result == xml_reader::parse_result::xml_not_complete)
+            {
+                throw storage_exception(protocol::error_xml_not_complete, true);
+            }
             return std::move(m_service_stats);
         }
 

--- a/Microsoft.WindowsAzure.Storage/includes/wascore/util.h
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/util.h
@@ -68,6 +68,7 @@ namespace azure { namespace storage { namespace core {
     pplx::task<void> complete_after(std::chrono::milliseconds timeout);
     std::vector<utility::string_t> string_split(const utility::string_t& string, const utility::string_t& separator);
     bool is_empty_or_whitespace(const utility::string_t& value);
+    bool has_whitespace_or_empty(const utility::string_t& str);
     utility::string_t single_quote(const utility::string_t& value);
     bool is_nan(double value);
     bool is_finite(double value);
@@ -77,6 +78,7 @@ namespace azure { namespace storage { namespace core {
     utility::string_t convert_to_string(const std::vector<uint8_t>& value);
     utility::string_t convert_to_string_with_fixed_length_fractional_seconds(utility::datetime value);
     utility::char_t utility_char_tolower(const utility::char_t& character);
+    utility::string_t str_trim_starting_trailing_whitespaces(const utility::string_t& str);
 
     template<typename T>
     utility::string_t convert_to_string(T value)

--- a/Microsoft.WindowsAzure.Storage/includes/wascore/xmlhelpers.h
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/xmlhelpers.h
@@ -64,13 +64,34 @@ class xml_reader
 {
 public:
 
+    /// <summary>
+    /// An enumeration describing result of the parse() operation.
+    /// </summary>
+    enum parse_result
+    {
+        /// <summary>
+        /// Parsed is finished and cannot be continued.
+        /// </summary>
+        cannot_continue = 0,
+
+        /// <summary>
+        /// Parse is paused and can be continued.
+        /// </summary>
+        can_continue = 1,
+
+        /// <summary>
+        /// Exited because XML is not complete.
+        /// </summary>
+        xml_not_complete = 2,
+    };
+
     virtual ~xml_reader() {}
 
     /// <summary>
-    /// Parse the given xml string/stream. Returns true if it finished parsing the stream to the end, and false
-    /// if it was asked to exit early via pause()
+    /// Parse the given xml string/stream. Return value indicates if
+    /// the parsing was successful.
     /// </summary>
-    bool parse();
+    parse_result parse();
 
 protected:
 

--- a/Microsoft.WindowsAzure.Storage/src/request_factory.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/request_factory.cpp
@@ -81,12 +81,23 @@ namespace azure { namespace storage { namespace protocol {
         web::http::http_headers& headers = request.headers();
         for (cloud_metadata::const_iterator it = metadata.cbegin(); it != metadata.cend(); ++it)
         {
+            if (core::has_whitespace_or_empty(it->first))
+            {
+                throw std::invalid_argument(protocol::error_empty_whitespace_metadata_name);
+            }
             if (core::is_empty_or_whitespace(it->second))
             {
                 throw std::invalid_argument(protocol::error_empty_metadata_value);
             }
-
-            headers.add(ms_header_metadata_prefix + it->first, it->second);
+            if (isspace(*it->second.begin()) || isspace(*it->second.rbegin()))
+            {
+                headers.add(ms_header_metadata_prefix + it->first, core::str_trim_starting_trailing_whitespaces(it->second));
+            }
+            else
+            {
+                headers.add(ms_header_metadata_prefix + it->first, it->second);
+            }
+            
         }
     }
 

--- a/Microsoft.WindowsAzure.Storage/src/table_request_factory.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/table_request_factory.cpp
@@ -447,6 +447,9 @@ namespace azure { namespace storage { namespace protocol {
         utility::string_t changeset_boundary_name = core::generate_boundary_name(_XPLATSTR("changeset"));
         
         web::http::http_request request = table_base_request(web::http::methods::POST, uri_builder, timeout, context);
+        // Need to reset the response buffer before each batch operation is executed.
+        response_buffer.collection().resize(0);
+        response_buffer.seekpos(0, std::ios_base::out);
         request.set_response_stream(Concurrency::streams::ostream(response_buffer));
 
         web::http::http_headers& request_headers = request.headers();

--- a/Microsoft.WindowsAzure.Storage/src/table_response_parsers.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/table_response_parsers.cpp
@@ -226,6 +226,12 @@ namespace azure { namespace storage { namespace protocol {
             }
         }
 
+        if (batch_result.size() != batch_size) {
+            std::string str;
+            str.reserve(128);
+            str.append(protocol::error_batch_size_not_match_response).append(" Sent ").append(std::to_string(batch_size)).append(" batch operations and received ").append(std::to_string(batch_result.size())).append(" batch results.");
+            throw storage_exception(str, false);
+        }
         return batch_result;
     }
 

--- a/Microsoft.WindowsAzure.Storage/src/util.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/util.cpp
@@ -168,6 +168,21 @@ namespace azure { namespace storage {  namespace core {
         return true;
     }
 
+    bool has_whitespace_or_empty(const utility::string_t& value)
+    {
+        if (value.empty()) return true;
+
+        for (utility::string_t::const_iterator it = value.cbegin(); it != value.cend(); ++it)
+        {
+            if (isspace(*it))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     utility::string_t single_quote(const utility::string_t& value)
     {
         const utility::char_t SINGLE_QUOTE = _XPLATSTR('\'');
@@ -273,6 +288,13 @@ namespace azure { namespace storage {  namespace core {
         }
 
         return result;
+    }
+
+    utility::string_t str_trim_starting_trailing_whitespaces(const utility::string_t& str)
+    {
+        auto non_space_begin = std::find_if(str.begin(), str.end(), std::not1(std::ptr_fun<int, int>(isspace)));
+        auto non_space_end = std::find_if(str.rbegin(), str.rend(), std::not1(std::ptr_fun<int, int>(isspace))).base();
+        return utility::string_t(non_space_begin, non_space_end);
     }
 
     utility::string_t convert_to_string_with_fixed_length_fractional_seconds(utility::datetime value)

--- a/Microsoft.WindowsAzure.Storage/tests/blob_test_base.cpp
+++ b/Microsoft.WindowsAzure.Storage/tests/blob_test_base.cpp
@@ -114,7 +114,7 @@ void blob_service_test_base::check_blob_equal(const azure::storage::cloud_blob& 
     CHECK_UTF8_EQUAL(expected.snapshot_qualified_uri().primary_uri().to_string(), actual.snapshot_qualified_uri().primary_uri().to_string());
     CHECK_UTF8_EQUAL(expected.snapshot_qualified_uri().secondary_uri().to_string(), actual.snapshot_qualified_uri().secondary_uri().to_string());
     check_blob_copy_state_equal(expected.copy_state(), actual.copy_state());
-    check_blob_properties_equal(expected.properties(), actual.properties());
+    check_blob_properties_equal(expected.properties(), actual.properties(), true);
 }
 
 void blob_service_test_base::check_blob_copy_state_equal(const azure::storage::copy_state& expected, const azure::storage::copy_state& actual)

--- a/Microsoft.WindowsAzure.Storage/tests/cloud_table_test.cpp
+++ b/Microsoft.WindowsAzure.Storage/tests/cloud_table_test.cpp
@@ -2732,9 +2732,11 @@ SUITE(Table)
             
             CHECK(output_document.is_object());
             CHECK(output_document.as_object().find(_XPLATSTR("DoubleProperty")) != output_document.as_object().cend());
-            CHECK_EQUAL(web::json::value::value_type::Number, output_document.as_object().find(_XPLATSTR("DoubleProperty"))->second.type());
-            CHECK(output_document.as_object().find(_XPLATSTR("DoubleProperty"))->second.is_double());
-            CHECK_EQUAL(double_value, output_document.as_object().find(_XPLATSTR("DoubleProperty"))->second.as_double());
+            auto num = output_document.as_object().find(_XPLATSTR("DoubleProperty"))->second;
+            CHECK_EQUAL(web::json::value::value_type::Number, num.type());
+            // Casablanca cannot take doubles like 0.0, 1.0, 2.00 to be double value, so if a number is seen as not a double but a integer, need to check that it is a whole number
+            CHECK(num.is_double() || (round(num.as_double()) == num.as_double()));
+            CHECK_EQUAL(double_value, num.as_double());
         }
     }
 


### PR DESCRIPTION
1.  Added check for metadata name that is empty or contains whitespaces to fail fast, and trimmed beginning/trailing whitespaces for metadata value. #180 #185 #186 
2. Resolved an issue where partial xml body will not throw exception when being parsed.
3. Resolved some test case issues.
4. Resolved an issue where retry for Table's batch operation always returns the first response. #187 