### PR TITLE
Bug fix for issue #193

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/was/table.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/table.h
@@ -577,6 +577,8 @@ namespace azure { namespace storage {
         /// <param name="value">The byte array value.</param>
         void set_value(const std::vector<uint8_t>& value)
         {
+            m_property_type = edm_type::binary;
+            m_is_null = false;
             set_value_impl(value);
         }
 

--- a/Microsoft.WindowsAzure.Storage/tests/cloud_table_test.cpp
+++ b/Microsoft.WindowsAzure.Storage/tests/cloud_table_test.cpp
@@ -134,6 +134,11 @@ SUITE(Table)
 
         CHECK(property.str().size() > 0);
 
+        // Reset property
+        property = azure::storage::entity_property(); 
+        CHECK(property.property_type() != azure::storage::edm_type::binary);
+        CHECK(property.is_null());
+
         value = get_random_binary_data();
         property.set_value(value);
 


### PR DESCRIPTION
This PR fixes #193 bug in member function `entity_property::set_value` for binary type. PR also includes updated unit test to verify validity of this fix.