### PR TITLE
Add a public set_storage_credentials method in cloud_client

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/was/service_client.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/service_client.h
@@ -69,7 +69,16 @@ namespace azure { namespace storage {
         {
             return m_base_uri;
         }
-
+        
+        /// <summary>
+        /// Sets the storage credentials to use for the service client.
+        /// </summary>
+        /// <param name="credentials">The <see cref="azure::storage::storage_credentials" /> to use.</param>
+        void set_storage_credentials(azure::storage::storage_credentials credentials)
+        {
+            m_credentials = std::move(credentials);
+        }
+        
         /// <summary>
         /// Gets the storage account credentials for the service client.
         /// </summary>


### PR DESCRIPTION
This is useful/needed to swap between primary and secondary shared access keys without recreating the client, in conjunction with retries and retry handling in `azure::storage::operation_context::set_response_received`.