### PR TITLE
Add the exception_ptr of the unhandled exception to retry_context

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/was/core.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/core.h
@@ -1203,6 +1203,7 @@ namespace azure { namespace storage {
         /// <param name="last_request_result">The last request result.</param>
         /// <param name="next_location">The next location to retry.</param>
         /// <param name="current_location_mode">The current location mode.</param>
+        /// <param name="ex_ptr">Exception Ptr of any exception other than storage_exception</param>
         retry_context(int current_retry_count, request_result last_request_result, storage_location next_location, location_mode current_location_mode, const std::exception_ptr& ex_ptr = nullptr)
             : m_current_retry_count(current_retry_count), m_last_request_result(std::move(last_request_result)), m_next_location(next_location), m_current_location_mode(current_location_mode), m_unhandled_exception(ex_ptr)
         {
@@ -1249,9 +1250,10 @@ namespace azure { namespace storage {
         }
 
         /// <summary>
-        /// Gets the results of the last request.
+        /// Gets the exception_ptr of any unhandled exception during the request.
+        /// Example: WinHttp exceptions for timeout (12002)
         /// </summary>
-        /// <returns>An <see cref="azure::storage::request_result" /> object that represents the results of the last request.</returns>
+        /// <returns>An <see cref="std::exception_ptr" /> object that represents the results of the last request.</returns>
         const request_result& last_request_result() const
         {
             return m_last_request_result;
@@ -1275,6 +1277,10 @@ namespace azure { namespace storage {
             return m_current_location_mode;
         }
 
+        /// <summary>
+        /// Gets the location mode for subsequent retries.
+        /// </summary>
+        /// <returns>The <see cref="azure::storage::location_mode" /> for subsequent retries.</returns>
         const std::exception_ptr& unhandled_exception() const {
             return m_unhandled_exception;
         }

--- a/Microsoft.WindowsAzure.Storage/includes/was/core.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/core.h
@@ -1203,9 +1203,9 @@ namespace azure { namespace storage {
         /// <param name="last_request_result">The last request result.</param>
         /// <param name="next_location">The next location to retry.</param>
         /// <param name="current_location_mode">The current location mode.</param>
-        /// <param name="ex_ptr">Exception Ptr of any exception other than storage_exception</param>
-        retry_context(int current_retry_count, request_result last_request_result, storage_location next_location, location_mode current_location_mode, const std::exception_ptr& ex_ptr = nullptr)
-            : m_current_retry_count(current_retry_count), m_last_request_result(std::move(last_request_result)), m_next_location(next_location), m_current_location_mode(current_location_mode), m_unhandled_exception(ex_ptr)
+        /// <param name="nonstorage_exception">Exception Ptr of any exception other than storage_exception</param>
+        retry_context(int current_retry_count, request_result last_request_result, storage_location next_location, location_mode current_location_mode, const std::exception_ptr& nonstorage_exception = nullptr)
+            : m_current_retry_count(current_retry_count), m_last_request_result(std::move(last_request_result)), m_next_location(next_location), m_current_location_mode(current_location_mode), m_nonstorage_exception(nonstorage_exception)
         {
         }
 
@@ -1250,10 +1250,10 @@ namespace azure { namespace storage {
         }
 
         /// <summary>
-        /// Gets the exception_ptr of any unhandled exception during the request.
+        /// Gets the results of the last request.
         /// Example: WinHttp exceptions for timeout (12002)
         /// </summary>
-        /// <returns>An <see cref="std::exception_ptr" /> object that represents the results of the last request.</returns>
+        /// <returns>An <see cref="azure::storage::request_result" /> object that represents the results of the last request.</returns>
         const request_result& last_request_result() const
         {
             return m_last_request_result;
@@ -1278,11 +1278,12 @@ namespace azure { namespace storage {
         }
 
         /// <summary>
-        /// Gets the location mode for subsequent retries.
+        /// Gets the exception_ptr of any unhandled nonstorage exception during the request.
+        /// Example: WinHttp exceptions for timeout (12002)
         /// </summary>
-        /// <returns>The <see cref="azure::storage::location_mode" /> for subsequent retries.</returns>
-        const std::exception_ptr& unhandled_exception() const {
-            return m_unhandled_exception;
+        /// <returns>An <see cref="std::exception_ptr" /> object that represents the nonstorage exception thrown while sending request</returns>
+        const std::exception_ptr& nonstorage_exception() const {
+            return m_nonstorage_exception;
         }
 
     private:
@@ -1291,7 +1292,7 @@ namespace azure { namespace storage {
         request_result m_last_request_result;
         storage_location m_next_location;
         location_mode m_current_location_mode;
-        std::exception_ptr m_unhandled_exception;
+        std::exception_ptr m_nonstorage_exception;
     };
 
     /// <summary>

--- a/Microsoft.WindowsAzure.Storage/includes/was/core.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/core.h
@@ -1203,8 +1203,8 @@ namespace azure { namespace storage {
         /// <param name="last_request_result">The last request result.</param>
         /// <param name="next_location">The next location to retry.</param>
         /// <param name="current_location_mode">The current location mode.</param>
-        retry_context(int current_retry_count, request_result last_request_result, storage_location next_location, location_mode current_location_mode)
-            : m_current_retry_count(current_retry_count), m_last_request_result(std::move(last_request_result)), m_next_location(next_location), m_current_location_mode(current_location_mode)
+        retry_context(int current_retry_count, request_result last_request_result, storage_location next_location, location_mode current_location_mode, const std::exception_ptr& ex_ptr = nullptr)
+            : m_current_retry_count(current_retry_count), m_last_request_result(std::move(last_request_result)), m_next_location(next_location), m_current_location_mode(current_location_mode), m_unhandled_exception(ex_ptr)
         {
         }
 
@@ -1275,12 +1275,17 @@ namespace azure { namespace storage {
             return m_current_location_mode;
         }
 
+        const std::exception_ptr& unhandled_exception() const {
+            return m_unhandled_exception;
+        }
+
     private:
 
         int m_current_retry_count;
         request_result m_last_request_result;
         storage_location m_next_location;
         location_mode m_current_location_mode;
+        std::exception_ptr m_unhandled_exception;
     };
 
     /// <summary>

--- a/Microsoft.WindowsAzure.Storage/includes/was/core.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/core.h
@@ -1251,7 +1251,6 @@ namespace azure { namespace storage {
 
         /// <summary>
         /// Gets the results of the last request.
-        /// Example: WinHttp exceptions for timeout (12002)
         /// </summary>
         /// <returns>An <see cref="azure::storage::request_result" /> object that represents the results of the last request.</returns>
         const request_result& last_request_result() const

--- a/Microsoft.WindowsAzure.Storage/src/executor.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/executor.cpp
@@ -285,7 +285,8 @@ namespace azure { namespace storage { namespace core {
             {
                 bool retryable_exception = true;
                 instance->m_context._get_impl()->add_request_result(instance->m_request_result);
-                std::exception_ptr ex_ptr = nullptr;
+                // Currently this holds exception pointer to non storage exceptions (exceptions thrown from cpp_rest)
+                std::exception_ptr nonstorage_ex_ptr = nullptr;
 
                 try
                 {
@@ -299,7 +300,7 @@ namespace azure { namespace storage { namespace core {
                         throw;
                     }
                     catch (...) {
-                        ex_ptr = std::current_exception();
+                        nonstorage_ex_ptr = std::current_exception();
                         throw;
                     }
                 }
@@ -341,7 +342,7 @@ namespace azure { namespace storage { namespace core {
                     }
 
                     // An exception occurred and thus the request might be retried. Ask the retry policy.
-                    retry_context context(instance->m_retry_count++, instance->m_request_result, instance->get_next_location(), instance->m_current_location_mode, ex_ptr);
+                    retry_context context(instance->m_retry_count++, instance->m_request_result, instance->get_next_location(), instance->m_current_location_mode, nonstorage_ex_ptr);
                     retry_info retry(instance->m_retry_policy.evaluate(context, instance->m_context));
                     if (!retry.should_retry())
                     {


### PR DESCRIPTION
Context:
This will give a better handling of exceptions especially winhttp errors (https://docs.microsoft.com/en-us/windows/win32/winhttp/error-messages) from clients overriding the azure::storage::Retry_policy. Currently our service is overriding your retry_policy. This gives us more flexibility to handle retries on append scenarios.

1) Added exception_ptr to retry_context
2) Pass the exception other than storage_exception to retry_context in excecutor.
