### PR TITLE
Allow to skip HTTPS certificates validation

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/was/common.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/common.h
@@ -2702,6 +2702,28 @@ namespace azure { namespace storage {
         }
 
         /// <summary>
+        /// Gets the server certificate validation property.
+        /// </summary>
+        /// <returns>True if certificates are to be verified, false otherwise</returns>
+        bool validate_certificates() const
+        {
+            return m_validate_certificates;
+        }
+
+        /// <summary>
+        /// Sets the server certificate validation property.
+        /// </summary>
+        /// <param name="validate_certificates">False to disable all server certificate validation, true otherwise.</param>
+        /// <remarks>
+        /// Disabling certificate validation is not recommended and will make the user exposed to unsecure environment.
+        /// Please use with caution and at your own risk.
+        /// </remarks>
+        void set_validate_certificates(bool validate_certificates)
+        {
+            m_validate_certificates = validate_certificates;
+        }
+
+        /// <summary>
         /// Gets the expiry time across all potential retries for the request.
         /// </summary>
         /// <returns>The expiry time.</returns>
@@ -2735,6 +2757,7 @@ namespace azure { namespace storage {
             m_maximum_execution_time.merge(other.m_maximum_execution_time);
             m_location_mode.merge(other.m_location_mode);
             m_http_buffer_size.merge(other.m_http_buffer_size);
+            m_validate_certificates.merge(other.m_validate_certificates);
 
             if (apply_expiry)
             {
@@ -2759,6 +2782,7 @@ namespace azure { namespace storage {
         option_with_default<std::chrono::milliseconds> m_maximum_execution_time;
         option_with_default<azure::storage::location_mode> m_location_mode;
         option_with_default<size_t> m_http_buffer_size;
+        option_with_default<bool> m_validate_certificates;
     };
 
     /// <summary>

--- a/Microsoft.WindowsAzure.Storage/includes/wascore/constants.h
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/constants.h
@@ -35,6 +35,7 @@ namespace azure { namespace storage { namespace protocol {
     const size_t default_stream_write_size = 4 * 1024 * 1024;
     const size_t default_stream_read_size = 4 * 1024 * 1024;
     const size_t default_buffer_size = 64 * 1024;
+    const bool default_validate_certificates = true;
     const utility::size64_t default_single_blob_upload_threshold = 128 * 1024 * 1024;
     const utility::size64_t default_single_blob_download_threshold = 32 * 1024 * 1024;
     const utility::size64_t default_single_block_download_threshold = 4 * 1024 * 1024;

--- a/Microsoft.WindowsAzure.Storage/src/cloud_common.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/cloud_common.cpp
@@ -31,7 +31,7 @@ namespace azure { namespace storage {
     WASTORAGE_API request_options::request_options()
         : m_location_mode(azure::storage::location_mode::primary_only), m_http_buffer_size(protocol::default_buffer_size),\
           m_maximum_execution_time(protocol::default_maximum_execution_time), m_server_timeout(protocol::default_server_timeout),\
-          m_noactivity_timeout(protocol::default_noactivity_timeout)
+          m_noactivity_timeout(protocol::default_noactivity_timeout),m_validate_certificates(protocol::default_validate_certificates)
     {
     }
 

--- a/Microsoft.WindowsAzure.Storage/src/executor.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/executor.cpp
@@ -150,6 +150,8 @@ namespace azure { namespace storage { namespace core {
             }
 #endif
 
+            config.set_validate_certificates(instance->m_request_options.validate_certificates());
+
             // 5-6. Potentially upload data and get response
             instance->assert_canceled();
 #ifdef _WIN32


### PR DESCRIPTION
Hello,

In my organization, it would be very handful to be able to disable the HTTPS verification, as it is explained in #295.
The machine using azure-storage-cpp only has access to the Azure storage host, and cannot validate the certificate through e.g. verisign.

Having this option allows us to keep using azure-storage-cpp using HTTPS in a very restricted environ of which we (developers) cannot control the network setup.

Any feedback are appreciated.