### PR TITLE
Fix problem with sanitize options on modern versions of gcc

### DIFF
--- a/Microsoft.WindowsAzure.Storage/src/request_result.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/request_result.cpp
@@ -29,7 +29,8 @@ namespace azure { namespace storage {
         m_target_location(target_location),
         m_end_time(utility::datetime::utc_now()),
         m_http_status_code(response.status_code()),
-        m_content_length(std::numeric_limits<utility::size64_t>::max())
+        m_content_length(std::numeric_limits<utility::size64_t>::max()),
+        m_request_server_encrypted(false)
     {
         parse_headers(response.headers());
         if (parse_body_as_error)
@@ -45,7 +46,8 @@ namespace azure { namespace storage {
         m_end_time(utility::datetime::utc_now()),
         m_http_status_code(http_status_code),
         m_extended_error(std::move(extended_error)),
-        m_content_length(std::numeric_limits<utility::size64_t>::max())
+        m_content_length(std::numeric_limits<utility::size64_t>::max()),
+        m_request_server_encrypted(false)
     {
         parse_headers(response.headers());
     }


### PR DESCRIPTION
Some of the constructors for request_result do not initialize the value
leading to complaints when the copy constructor is used.

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>