### PR TITLE
Add thread safe public set_storage_credentials to cloud_client

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/was/core.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/core.h
@@ -233,9 +233,8 @@ namespace azure { namespace storage {
         /// </summary>
         /// <param name="account_name">A string containing the name of the storage account.</param>
         /// <param name="account_key">A string containing the Base64-encoded account access key.</param>
-        storage_credentials(utility::string_t account_name, const utility::string_t& account_key) : m_account_name(std::move(account_name)), m_account_key_credential(std::make_shared<account_key_credential>())
+        storage_credentials(utility::string_t account_name, const utility::string_t& account_key) : m_account_name(std::move(account_name)), m_account_key_credential(std::make_shared<account_key_credential>(utility::conversions::from_base64(account_key)))
         {
-            m_account_key_credential->m_account_key = std::move(utility::conversions::from_base64(account_key));
         }
 
         /// <summary>
@@ -243,9 +242,8 @@ namespace azure { namespace storage {
         /// </summary>
         /// <param name="account_name">A string containing the name of the storage account.</param>
         /// <param name="account_key">An array of bytes that represent the account access key.</param>
-        storage_credentials(utility::string_t account_name, std::vector<uint8_t> account_key) : m_account_name(std::move(account_name)), m_account_key_credential(std::make_shared<account_key_credential>())
+        storage_credentials(utility::string_t account_name, std::vector<uint8_t> account_key) : m_account_name(std::move(account_name)), m_account_key_credential(std::make_shared<account_key_credential>(std::move(account_key)))
         {
-            m_account_key_credential->m_account_key = std::move(account_key);
         }
 
         class sas_credential
@@ -410,7 +408,7 @@ namespace azure { namespace storage {
         }
 
         /// <summary>
-        /// Sets the accounts for the credentials.
+        /// Sets the account key for the credentials.
         /// </summary>
         /// <param name="account_key">A string containing the Base64-encoded account access key.</param>
         void set_account_key(const utility::string_t& account_key)
@@ -419,7 +417,7 @@ namespace azure { namespace storage {
         }
 
         /// <summary>
-        /// Sets the accounts for the credentials.
+        /// Sets the account key for the credentials.
         /// </summary>
         /// <param name="account_key">An array of bytes that represent the account access key.</param>
         void set_account_key(std::vector<uint8_t> account_key)

--- a/Microsoft.WindowsAzure.Storage/includes/was/service_client.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/service_client.h
@@ -74,9 +74,20 @@ namespace azure { namespace storage {
         /// Gets the storage account credentials for the service client.
         /// </summary>
         /// <returns>The storage account credentials for the service client.</returns>
-        const azure::storage::storage_credentials& credentials() const
+        const azure::storage::storage_credentials& credentials()
         {
+            pplx::extensibility::scoped_read_lock_t guard(m_mutex);
             return m_credentials;
+        }
+
+        /// <summary>
+        /// Sets the storage credentials to use for the service client.
+        /// </summary>
+        /// <param name="credentials">The <see cref="azure::storage::storage_credentials" /> to use.</param>
+        void set_storage_credentials(azure::storage::storage_credentials credentials)
+        {
+            pplx::extensibility::scoped_rw_lock_t guard(m_mutex);
+            m_credentials = std::move(credentials);
         }
 
         /// <summary>
@@ -150,6 +161,7 @@ namespace azure { namespace storage {
 
     private:
 
+        pplx::extensibility::reader_writer_lock_t m_mutex;
         storage_uri m_base_uri;
         azure::storage::storage_credentials m_credentials;
         azure::storage::authentication_scheme m_authentication_scheme;

--- a/Microsoft.WindowsAzure.Storage/includes/was/service_client.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/service_client.h
@@ -74,20 +74,9 @@ namespace azure { namespace storage {
         /// Gets the storage account credentials for the service client.
         /// </summary>
         /// <returns>The storage account credentials for the service client.</returns>
-        const azure::storage::storage_credentials& credentials()
+        const azure::storage::storage_credentials& credentials() const
         {
-            pplx::extensibility::scoped_read_lock_t guard(m_mutex);
             return m_credentials;
-        }
-
-        /// <summary>
-        /// Sets the storage credentials to use for the service client.
-        /// </summary>
-        /// <param name="credentials">The <see cref="azure::storage::storage_credentials" /> to use.</param>
-        void set_storage_credentials(azure::storage::storage_credentials credentials)
-        {
-            pplx::extensibility::scoped_rw_lock_t guard(m_mutex);
-            m_credentials = std::move(credentials);
         }
 
         /// <summary>
@@ -161,7 +150,6 @@ namespace azure { namespace storage {
 
     private:
 
-        pplx::extensibility::reader_writer_lock_t m_mutex;
         storage_uri m_base_uri;
         azure::storage::storage_credentials m_credentials;
         azure::storage::authentication_scheme m_authentication_scheme;

--- a/Microsoft.WindowsAzure.Storage/tests/cloud_storage_account_test.cpp
+++ b/Microsoft.WindowsAzure.Storage/tests/cloud_storage_account_test.cpp
@@ -42,7 +42,9 @@ void check_credentials_equal(const azure::storage::storage_credentials& a, const
     CHECK_EQUAL(a.is_sas(), b.is_sas());
     CHECK_EQUAL(a.is_shared_key(), b.is_shared_key());
     CHECK_UTF8_EQUAL(a.account_name(), b.account_name());
-    CHECK_UTF8_EQUAL(utility::conversions::to_base64(a.account_key()), utility::conversions::to_base64(b.account_key()));
+    if (a.is_shared_key() && b.is_shared_key()) {
+        CHECK_UTF8_EQUAL(utility::conversions::to_base64(a.account_key()), utility::conversions::to_base64(b.account_key()));
+    }
 }
 
 void check_account_equal(azure::storage::cloud_storage_account& a, azure::storage::cloud_storage_account& b)

--- a/Microsoft.WindowsAzure.Storage/tests/cloud_storage_account_test.cpp
+++ b/Microsoft.WindowsAzure.Storage/tests/cloud_storage_account_test.cpp
@@ -487,7 +487,7 @@ SUITE(Core)
 
             CHECK_UTF8_EQUAL(token, creds.sas_token());
             CHECK(creds.account_name().empty());
-            CHECK(creds.account_key().empty());
+            CHECK(!creds.is_account_key());
             CHECK(!creds.is_anonymous());
             CHECK(creds.is_sas());
             CHECK(!creds.is_shared_key());
@@ -502,7 +502,7 @@ SUITE(Core)
 
             CHECK_UTF8_EQUAL(token, creds.sas_token());
             CHECK(creds.account_name().empty());
-            CHECK(creds.account_key().empty());
+            CHECK(!creds.is_account_key());
             CHECK(!creds.is_anonymous());
             CHECK(creds.is_sas());
             CHECK(!creds.is_shared_key());


### PR DESCRIPTION
This is useful/needed to swap between primary and secondary shared access keys without recreating the client, in conjunction with retries and retry handling in azure::storage::operation_context::set_response_received. Currently, access key expiry during operation would result in need to recreate client. 

Adding thread safety on top of PR #303 