### PR TITLE
Isolate pragmas specific for VisualStudio

### DIFF
--- a/Microsoft.WindowsAzure.Storage/includes/stdafx.h
+++ b/Microsoft.WindowsAzure.Storage/includes/stdafx.h
@@ -24,8 +24,10 @@
 
 #include "targetver.h"
 
+#ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4634 4635 4638 4251 4100 4503 4996)
+#endif
 
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -49,6 +51,8 @@
 #include "cpprest/filestream.h"
 #include "cpprest/producerconsumerstream.h"
 
+#ifdef _MSC_VER
 #pragma warning(pop)
 
 #pragma warning(disable: 4503)
+#endif

--- a/Microsoft.WindowsAzure.Storage/includes/was/auth.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/auth.h
@@ -37,7 +37,9 @@ namespace azure { namespace storage { namespace protocol {
     const utility::string_t auth_name_shared_key(_XPLATSTR("SharedKey"));
     const utility::string_t auth_name_shared_key_lite(_XPLATSTR("SharedKeyLite"));
 
+#ifdef _MSC_VER
 #pragma region Canonicalization
+#endif
 
     /// <summary>
     /// A helper class for constructing the canonicalization strings required to authenticate a request.
@@ -357,9 +359,11 @@ namespace azure { namespace storage { namespace protocol {
         }
     };
 
+#ifdef _MSC_VER
 #pragma endregion
 
 #pragma region Authentication Handlers
+#endif
 
     /// <summary>
     /// A helper class for signing a request for the desired authentication scheme.
@@ -466,9 +470,11 @@ namespace azure { namespace storage { namespace protocol {
         storage_credentials m_credentials;
     };
 
+#ifdef _MSC_VER
 #pragma endregion
 
 #pragma region Shared Access Signatures
+#endif
 
     utility::string_t get_account_sas_token(const utility::string_t& identifier, const account_shared_access_policy& policy, const storage_credentials& credentials);
     utility::string_t get_blob_sas_token(const utility::string_t& identifier, const shared_access_policy& policy, const cloud_blob_shared_access_headers& headers, const utility::string_t& resource_type, const utility::string_t& resource, const utility::string_t& snapshot_time, const storage_credentials& credentials);
@@ -478,6 +484,8 @@ namespace azure { namespace storage { namespace protocol {
     utility::string_t get_blob_user_delegation_sas_token(const shared_access_policy& policy, const cloud_blob_shared_access_headers& headers, const utility::string_t& resource_type, const utility::string_t& resource, const utility::string_t& snapshot_time, const user_delegation_key& key);
     storage_credentials parse_query(const web::http::uri& uri, bool require_signed_resource);
 
+#ifdef _MSC_VER
 #pragma endregion
+#endif
 
 }}} // namespace azure::storage::protocol

--- a/Microsoft.WindowsAzure.Storage/includes/was/error_code_strings.h
+++ b/Microsoft.WindowsAzure.Storage/includes/was/error_code_strings.h
@@ -21,7 +21,9 @@
 
 namespace azure { namespace storage { namespace protocol {
 
+#ifdef _MSC_VER
 #pragma region storage_error_code_strings
+#endif
 
     // This section provides error code strings that are common to all storage services.
 
@@ -231,9 +233,11 @@ namespace azure { namespace storage { namespace protocol {
     /// </summary>
     const utility::string_t error_code_resource_type_mismatch(_XPLATSTR("ResourceTypeMismatch"));
 
+#ifdef _MSC_VER
 #pragma endregion
 
 #pragma region blob_error_code_strings
+#endif
 
     // This section provides error code strings that are specific to the Blob service.
 
@@ -427,9 +431,11 @@ namespace azure { namespace storage { namespace protocol {
     /// </summary>
     const utility::string_t error_code_copy_id_mismatch(_XPLATSTR("CopyIdMismatch"));
 
+#ifdef _MSC_VER
 #pragma endregion
 
 #pragma region table_error_code_strings
+#endif
 
     // This section provides error code strings that are specific to the Table service.
 
@@ -583,9 +589,11 @@ namespace azure { namespace storage { namespace protocol {
     /// </summary>
     const utility::string_t error_code_host_information_not_present(_XPLATSTR("HostInformationNotPresent"));
 
+#ifdef _MSC_VER
 #pragma endregion
 
 #pragma region queue_error_code_strings
+#endif
 
     // This section provides error code strings that are specific to the Queue service.
 
@@ -639,6 +647,8 @@ namespace azure { namespace storage { namespace protocol {
     /// </summary>
     const utility::string_t error_code_invalid_marker(_XPLATSTR("InvalidMarker"));
 
+#ifdef _MSC_VER
 #pragma endregion
+#endif
 
 }}} // namespace azure::storage::protocol

--- a/Microsoft.WindowsAzure.Storage/includes/wascore/basic_types.h
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/basic_types.h
@@ -16,7 +16,9 @@
 // -----------------------------------------------------------------------------------------
 
 #pragma once
+#ifdef _MSC_VER
 #pragma warning(disable: 4634)
+#endif
 
 #include "cpprest/details/basic_types.h"
 

--- a/Microsoft.WindowsAzure.Storage/includes/wascore/util.h
+++ b/Microsoft.WindowsAzure.Storage/includes/wascore/util.h
@@ -32,7 +32,9 @@
 
 namespace azure { namespace storage { namespace core {
 
+#ifdef _MSC_VER
 #pragma region Navigation Helpers
+#endif
 
     bool use_path_style(const storage_uri& uri);
     utility::string_t::size_type find_path_start(const web::http::uri& uri);
@@ -48,9 +50,11 @@ namespace azure { namespace storage { namespace core {
     bool parse_object_uri(const storage_uri& uri, utility::string_t& object_name);
     storage_uri get_service_client_uri(const storage_uri& uri);
 
+#ifdef _MSC_VER
 #pragma endregion
 
 #pragma region MIME Helpers
+#endif
 
     utility::string_t generate_boundary_name(const utility::string_t& prefix);
     void write_boundary(utility::string_t& body_text, const utility::string_t& boundary_name, bool is_closure = false);
@@ -59,9 +63,11 @@ namespace azure { namespace storage { namespace core {
     void write_request_headers(utility::string_t& body_text, const web::http::http_headers& headers);
     void write_request_payload(utility::string_t& body_text, const web::json::value& json_object);
 
+#ifdef _MSC_VER
 #pragma endregion
 
 #pragma region Common Utilities
+#endif
 
     utility::string_t make_query_parameter(const utility::string_t& parameter_name, const utility::string_t& parameter_value, bool do_encoding = true);
     utility::size64_t get_remaining_stream_length(concurrency::streams::istream stream);
@@ -115,7 +121,9 @@ namespace azure { namespace storage { namespace core {
         return make_query_parameter(parameter_name, convert_to_string(parameter_value), do_encoding);
     }
 
+#ifdef _MSC_VER
 #pragma endregion
+#endif
 
 #ifndef _WIN32
     class http_client_reusable


### PR DESCRIPTION
When using azure-storage-cpp libraries with gcc and with the -Wall option the azure-storage-cpp is reporting several unknown pragma.

This pull request is to remove some specific Microsoft Visual Studio pragma from the public API.