### PR TITLE
Removing the signed-resource requirement for account SAS tokens

### DIFF
--- a/Microsoft.WindowsAzure.Storage/src/shared_access_signature.cpp
+++ b/Microsoft.WindowsAzure.Storage/src/shared_access_signature.cpp
@@ -115,12 +115,6 @@ namespace azure { namespace storage { namespace protocol {
             splitted_query.erase(remove_param);
         }
 
-        auto signed_resource = splitted_query.find(protocol::uri_query_sas_resource);
-        if (require_signed_resource && signed_resource == splitted_query.end())
-        {
-            throw std::invalid_argument(protocol::error_missing_params_for_sas);
-        }
-
         web::http::uri_builder builder;
         for (auto iter = splitted_query.cbegin(); iter != splitted_query.cend(); ++iter)
         {


### PR DESCRIPTION
Addressing the following bug: [https://github.com/Azure/azure-storage-cpp/issues/383](https://github.com/Azure/azure-storage-cpp/issues/383)